### PR TITLE
COOPR-672 Miscellaneous Package Management

### DIFF
--- a/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -25,8 +25,8 @@ when 'rhel'
   include_recipe 'yum-epel::default' if node['base']['use_epel'].to_s == 'true'
 end
 
-# We always run our dns, firewall, and hosts cookbooks
-%w(dns firewall hosts).each do |cb|
+# We always run our dns, firewall, hosts, and packages cookbooks
+%w(dns firewall hosts packages).each do |cb|
   include_recipe "coopr_#{cb}::default" unless node['base'].key?("no_#{cb}") && node['base']["no_#{cb}"].to_s == 'true'
 end
 

--- a/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/attributes/default.rb
+++ b/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/attributes/default.rb
@@ -1,0 +1,6 @@
+default['coopr_packages']['debian']['install'] = []
+default['coopr_packages']['debian']['upgrade'] = []
+default['coopr_packages']['debian']['remove'] = []
+default['coopr_packages']['rhel']['install'] = []
+default['coopr_packages']['rhel']['upgrade'] = []
+default['coopr_packages']['rhel']['remove'] = ['yum-cron']

--- a/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
+++ b/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
@@ -1,0 +1,7 @@
+name             'coopr_packages'
+maintainer       'Cask Data, Inc.'
+maintainer_email 'ops@cask.co'
+license          'Apache 2.0'
+description      'Installs/Removes a defined set of packages'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'

--- a/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: coopr_packages
+# Recipe:: default
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+%w(install upgrade remove).each do |act|
+  node['coopr_packages'][node['platform_family']][act].each do |cb|
+    package cb do
+      action act.to_sym
+    end
+  end
+end


### PR DESCRIPTION
Google adds the `yum-cron` package to its CentOS images. This can cause issues for clusters built with specific versions of packages where newer versions may be available. However, this may not be desirable for all uses, so a generic package management cookbook was created. This cookbook allows the following actions on packages, per Chef `platform_family`: install, upgrade, remove.
