### PR TITLE
COOPR-585 Improve provider hostname support

### DIFF
--- a/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -90,9 +90,9 @@ class FogProviderAWS < Provider
       domainname = @task['config']['hostname'].split('.').drop(1).join('.')
 
       hostname =
-        if !server.dns_name.nil? && domainname = 'local'
+        if !server.dns_name.nil? && domainname == 'local'
           server.dns_name
-        elsif !server.public_ip_address.nil? && domainname = 'local'
+        elsif !server.public_ip_address.nil? && domainname == 'local'
           Resolv.getname(server.public_ip_address)
         else
           @task['config']['hostname']

--- a/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -86,10 +86,13 @@ class FogProviderAWS < Provider
       log.debug "Waiting for server to come up: #{providerid}"
       server.wait_for(600) { ready? }
 
+      # Get domain name by dropping first dot
+      domainname = @task['config']['hostname'].split('.').drop(1).join('.')
+
       hostname =
-        if !server.dns_name.nil?
+        if !server.dns_name.nil? && domainname = 'local'
           server.dns_name
-        elsif !server.public_ip_address.nil?
+        elsif !server.public_ip_address.nil? && domainname = 'local'
           Resolv.getname(server.public_ip_address)
         else
           @task['config']['hostname']

--- a/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -121,8 +121,11 @@ class FogProviderGoogle < Provider
       log.debug "Waiting for server to come up: #{providerid}"
       server.wait_for(600) { ready? }
 
+      # Get domain name by dropping first dot
+      domainname = @task['config']['hostname'].split('.').drop(1).join('.')
+
       hostname =
-        if server.public_ip_address
+        if server.public_ip_address && domainname == 'local'
           Resolv.getname(server.public_ip_address)
         else
           @task['config']['hostname']


### PR DESCRIPTION
AWS and Google provide forward/reverse DNS entries for their cloud instances. Currently, we prefer these DNS names over the Coopr-provided hostnames. Instead, we should assume the Coopr-provided hostname is good if the user has specified a DNS suffix for the cluster.
