### PR TITLE
prevent nilpointer

### DIFF
--- a/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/metadata.rb
+++ b/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/metadata.rb
@@ -9,6 +9,7 @@ version '0.1.1'
 depends 'coopr_dns'
 depends 'coopr_firewall'
 depends 'coopr_hosts'
+depends 'coopr_packages'
 
 depends 'apt'
 depends 'yum-epel'

--- a/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -17,8 +17,9 @@
 # limitations under the License.
 #
 
+pf = node['platform_family']
 %w(install upgrade remove).each do |act|
-  node['coopr_packages'][node['platform_family']][act].each do |cb|
+  node['coopr_packages'][pf][act].each do |cb|
     package cb do
       action act.to_sym
     end


### PR DESCRIPTION
Update:  the real problem was a missing dependency in coopr_base.  The first commit is probably unecessary but i still think is cleaner as it is here
