### PR TITLE
Feature/fix delete

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -268,8 +268,12 @@ class FogProviderAWS < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
+        raise ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
+      rescue ArgumentError
+        log.debug "Invalid provider id #{providerid} specified on delete... skipping"
+      end
       rescue NoMethodError
         log.warn "Could not locate server '#{providerid}'... skipping"
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -268,7 +268,7 @@ class FogProviderAWS < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
-        raise ArgumentError if providerid.nil? || providerid.empty?
+        fail ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
       rescue ArgumentError

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -273,7 +273,6 @@ class FogProviderAWS < Provider
         server.destroy
       rescue ArgumentError
         log.debug "Invalid provider id #{providerid} specified on delete... skipping"
-      end
       rescue NoMethodError
         log.warn "Could not locate server '#{providerid}'... skipping"
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -180,8 +180,11 @@ class FogProviderDigitalOcean < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
+        raise ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
+      rescue ArgumentError
+        log.debug "Invalid provider id #{providerid} specified on delete... skipping"
       rescue NoMethodError
         log.warn "Could not locate server '#{providerid}'... skipping"
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -180,7 +180,7 @@ class FogProviderDigitalOcean < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
-        raise ArgumentError if providerid.nil? || providerid.empty?
+        fail ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
       rescue ArgumentError

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -246,7 +246,8 @@ class FogProviderGoogle < Provider
 
       # fetch server object
       begin
-        server = connection.servers.get(providerid)
+        # check for nil providerid in case of failed servers, and prevent Fog lookup
+        server = providerid.nil? || providerid.empty? ? nil : connection.servers.get(providerid)
       rescue ArgumentError => e
         # ok, attempting to delete a server with an invalid name which cannot exist at the provider
         log.debug("ArgumentError in when deleting server #{providerid}. Server must not exist: " + e.inspect)

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -225,7 +225,7 @@ class FogProviderJoyent < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
-        raise ArgumentError if providerid.nil? || providerid.empty?
+        fail ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
       rescue ArgumentError

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -225,8 +225,11 @@ class FogProviderJoyent < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
+        raise ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
+      rescue ArgumentError
+        log.debug "Invalid provider id #{providerid} specified on delete... skipping"
       rescue NoMethodError, Fog::Compute::Joyent::Errors::NotFound
         log.warn "Could not locate server '#{providerid}'... skipping"
       else

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -174,8 +174,11 @@ class FogProviderOpenstack < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
+        raise ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
+      rescue ArgumentError
+        log.debug "Invalid provider id #{providerid} specified on delete... skipping"
       rescue NoMethodError
         log.warn "Could not locate server '#{providerid}'... skipping"
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -174,7 +174,7 @@ class FogProviderOpenstack < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
-        raise ArgumentError if providerid.nil? || providerid.empty?
+        fail ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
       rescue ArgumentError

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -162,8 +162,11 @@ class FogProviderRackspace < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
+        raise ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
+      rescue ArgumentError
+        log.debug "Invalid provider id #{providerid} specified on delete... skipping"
       rescue NoMethodError
         log.warn "Could not locate server '#{providerid}'... skipping"
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -162,7 +162,7 @@ class FogProviderRackspace < Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
-        raise ArgumentError if providerid.nil? || providerid.empty?
+        fail ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
       rescue ArgumentError


### PR DESCRIPTION
Fixes https://issues.cask.co/browse/COOPR-692
- [x] checks that the given providerid is not nil or empty before looking up servers to delete via fog

Note, google has a slightly different implementation due to further disk processing
