### PR TITLE
Feature/refactor worker todo poll interval config

### DIFF
--- a/conf/provisioner-default.xml
+++ b/conf/provisioner-default.xml
@@ -94,7 +94,7 @@
   <property>
     <name>provisioner.worker.poll.error.interval</name>
     <value>10</value>
-    <description>interval in seconds to wait after an unsuccessfully polling the server for tasks</description>
+    <description>interval in seconds to wait after unsuccessfully polling the server for tasks</description>
   </property>
 </configuration>
 

--- a/conf/provisioner-default.xml
+++ b/conf/provisioner-default.xml
@@ -66,5 +66,15 @@
     <value>info</value>
     <description>log level, one of debug, info, warn, error, fatal</description>
   </property>
+  <property>
+    <name>provisioner.worker.poll.interval</name>
+    <value>1</value>
+    <description>interval in seconds to poll server for tasks</description>
+  </property>
+  <property>
+    <name>provisioner.worker.poll.error.interval</name>
+    <value>10</value>
+    <description>interval in seconds to wait after an unsuccessfully polling the server for tasks</description>
+  </property>
 </configuration>
 

--- a/lib/provisioner/constants.rb
+++ b/lib/provisioner/constants.rb
@@ -30,6 +30,8 @@ module Coopr
   PROVISIONER_LOG_ROTATION_SHIFT_AGE = 'provisioner.log.rotation.shift.age'
   PROVISIONER_LOG_ROTATION_SHIFT_SIZE = 'provisioner.log.rotation.shift.size'
   PROVISIONER_LOG_LEVEL = 'provisioner.log.level'
+  PROVISIONER_WORKER_POLL_INTERVAL = 'provisioner.worker.poll.interval'
+  PROVISIONER_WORKER_POLL_ERROR_INTERVAL = 'provisioner.worker.poll.error.interval'
   TRUST_CERT_PATH = 'trust.cert.path'
   TRUST_CERT_PASS = 'trust.cert.pass'
 

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -53,6 +53,9 @@ module Coopr
       host = Socket.gethostname.downcase
       @worker_id = "#{host}.#{pid}"
 
+      # Set logging process name field
+      Logging.process_name = @worker_id
+
       # Logging module is already configured via the master provisioner or self.run
       # TODO: reimplement functionality to log each worker to a different file
       #   if (new config option)

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -240,7 +240,7 @@ module Coopr
     end
 
     # Poll Coopr Server for a task, retries until it gets some response
-    def poll_server
+    def _poll_server
       server_uri = @config.get(PROVISIONER_SERVER_URI)
       poll_error_interval = @config.get(PROVISIONER_WORKER_POLL_ERROR_INTERVAL).to_i || 10
       postdata = { 'provisionerId' => @provisioner_id, 'workerId' => @worker_id, 'tenantId' => @tenant }.to_json
@@ -255,13 +255,13 @@ module Coopr
       }
     end
 
-    # Poll Coopr Server for a task, retries until a task is successfully received
-    def _poll_server_and_wait_for_task
+    # Poll Coopr Server for a task, retries until a task is successfully retrieved
+    def _poll_server_and_retrieve_task
       poll_interval = @config.get(PROVISIONER_WORKER_POLL_INTERVAL).to_i || 1
       poll_error_interval = @config.get(PROVISIONER_WORKER_POLL_ERROR_INTERVAL).to_i || 10
       loop {
         begin
-          response = _poll_server_for_response
+          response = _poll_server
           if response.code == 200 && response.to_str && response.to_str != ''
             task = JSON.parse(response.to_str)
             break task
@@ -291,8 +291,8 @@ module Coopr
       loop {
         result = nil
 
-        # Poll Coopr Server until a task is received
-        task = _poll_server_and_wait_for_task
+        # Poll Coopr Server until a task is retrieved
+        task = _poll_server_and_retrieve_task
 
         # While running task, trap and queue TERM signal to prevent shutdown until task is complete
         sigterm = Coopr::Worker::SignalHandler.new('TERM')

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -254,7 +254,6 @@ module Coopr
           response = Coopr::RestHelper.post "#{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/take", { 'provisionerId' => @provisioner_id, 'workerId' => myid, 'tenantId' => @tenant }.to_json
         rescue => e
           log.error "Caught exception connecting to coopr server #{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/take: #{e}"
-          puts "cant connect"
           sleep poll_error_interval
           next
         end
@@ -265,12 +264,10 @@ module Coopr
             log.debug "Received task from server <#{response.to_str}>"
           elsif response.code == 204
             break if @once
-            puts "no work"
             sleep poll_interval
             next
           else
             log.error "Received error code #{response.code} from coopr server: #{response.to_str}"
-            puts "error from server"
             sleep poll_error_interval
             next
           end

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -51,7 +51,7 @@ module Coopr
       @config = config
       pid = Process.pid
       host = Socket.gethostname.downcase
-      @worker_id = "#{host}.#{pid}
+      @worker_id = "#{host}.#{pid}"
 
       # Logging module is already configured via the master provisioner or self.run
       # TODO: reimplement functionality to log each worker to a different file

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -49,6 +49,9 @@ module Coopr
     def initialize(options, config)
       @options = options
       @config = config
+      pid = Process.pid
+      host = Socket.gethostname.downcase
+      @worker_id = "#{host}.#{pid}
 
       # Logging module is already configured via the master provisioner or self.run
       # TODO: reimplement functionality to log each worker to a different file
@@ -233,71 +236,84 @@ module Coopr
       end
     end
 
-    # Run in continuous server polling mode
-    def work
-      pid = Process.pid
-      host = Socket.gethostname.downcase
-      myid = "#{host}.#{pid}"
+    # Poll Coopr Server for a task, retries until it gets some response
+    def poll_server
+      server_uri = @config.get(PROVISIONER_SERVER_URI)
+      poll_error_interval = @config.get(PROVISIONER_WORKER_POLL_ERROR_INTERVAL).to_i || 10
+      postdata = { 'provisionerId' => @provisioner_id, 'workerId' => @worker_id, 'tenantId' => @tenant }.to_json
+      loop {
+        begin
+          response = Coopr::RestHelper.post "#{server_uri}/v2/tasks/take", postdata
+          break response
+        rescue => e
+          log.error "Unable to connect to Coopr Server #{server_uri}/v2/tasks/take: #{e}"
+          sleep poll_error_interval
+        end
+      }
+    end
+
+    # Poll Coopr Server for a task, retries until a task is successfully received
+    def _poll_server_and_wait_for_task
       poll_interval = @config.get(PROVISIONER_WORKER_POLL_INTERVAL).to_i || 1
       poll_error_interval = @config.get(PROVISIONER_WORKER_POLL_ERROR_INTERVAL).to_i || 10
-
-
-      $PROGRAM_NAME = "#{$PROGRAM_NAME} (tenant: #{@tenant}, provisioner: #{@provisioner_id}, worker: #{@name})"
-
-      log.info "Starting worker with id #{myid}, connecting to server #{@config.get(PROVISIONER_SERVER_URI)}"
-
       loop {
-        result = nil
-        response = nil
-        task = nil
         begin
-          response = Coopr::RestHelper.post "#{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/take", { 'provisionerId' => @provisioner_id, 'workerId' => myid, 'tenantId' => @tenant }.to_json
-        rescue => e
-          log.error "Caught exception connecting to coopr server #{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/take: #{e}"
-          sleep poll_error_interval
-          next
-        end
-
-        begin
+          response = _poll_server_for_response
           if response.code == 200 && response.to_str && response.to_str != ''
             task = JSON.parse(response.to_str)
-            log.debug "Received task from server <#{response.to_str}>"
+            break task
           elsif response.code == 204
-            break if @once
             sleep poll_interval
             next
           else
             log.error "Received error code #{response.code} from coopr server: #{response.to_str}"
-            sleep poll_error_interval
-            next
           end
         rescue => e
           log.error "Caught exception processing response from coopr server: #{e.inspect}"
         end
+        sleep poll_error_interval
+      }
+    end
 
-        # While provisioning, don't allow the worker to terminate by disabling signal
+    # Run in continuous server polling mode
+    def work
+      poll_interval = @config.get(PROVISIONER_WORKER_POLL_INTERVAL).to_i || 1
+      poll_error_interval = @config.get(PROVISIONER_WORKER_POLL_ERROR_INTERVAL).to_i || 10
+      server_uri = @config.get(PROVISIONER_SERVER_URI)
+
+      $PROGRAM_NAME = "#{$PROGRAM_NAME} (tenant: #{@tenant}, provisioner: #{@provisioner_id}, worker: #{@name})"
+
+      log.info "Starting worker with id #{@worker_id}, connecting to server #{@config.get(PROVISIONER_SERVER_URI)}"
+
+      loop {
+        result = nil
+
+        # Poll Coopr Server until a task is received
+        task = _poll_server_and_wait_for_task
+
+        # While running task, trap and queue TERM signal to prevent shutdown until task is complete
         sigterm = Coopr::Worker::SignalHandler.new('TERM')
         sigterm.dont_interupt {
           begin
             result = delegate_task(task, @pluginmanager) # TODO: we dont need to pass pluginmanager anymore
 
             result = Hash.new if result.nil? == true
-            result['workerId'] = myid
+            result['workerId'] = @worker_id
             result['taskId'] = task['taskId']
             result['provisionerId'] = @provisioner_id
             result['tenantId'] = @tenant
 
             log.debug "Task <#{task['taskId']}> completed, updating results <#{result}>"
             begin
-              response = Coopr::RestHelper.post "#{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/finish", result.to_json
+              response = Coopr::RestHelper.post "#{server_uri}/v2/tasks/finish", result.to_json
             rescue => e
-              log.error "Caught exception posting back to coopr server #{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/finish: #{e}"
+              log.error "Caught exception posting back to coopr server #{server_uri}/v2/tasks/finish: #{e}"
             end
 
           rescue => e
             result = Hash.new if result.nil? == true
             result['status'] = '1'
-            result['workerId'] = myid
+            result['workerId'] = @worker_id
             result['taskId'] = task['taskId']
             result['provisionerId'] = @provisioner_id
             result['tenantId'] = @tenant
@@ -311,9 +327,9 @@ module Coopr
             end
             log.error "Task <#{task['taskId']}> failed, updating results <#{result}>"
             begin
-              response = Coopr::RestHelper.post "#{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/finish", result.to_json
+              response = Coopr::RestHelper.post "#{server_uri}/v2/tasks/finish", result.to_json
             rescue => e
-              log.error "Caught exception posting back to server #{@config.get(PROVISIONER_SERVER_URI)}/v2/tasks/finish: #{e}"
+              log.error "Caught exception posting back to server #{server_uri}/v2/tasks/finish: #{e}"
             end
           end
         }


### PR DESCRIPTION
- [x] addressed the TODO for adding configuration options for the polling intervals.  This actually pushed rubocop over its complexity thresholds, so...
- [x] split the polling logic out into its own methods instead of `.work`.
