### PR TITLE
COOPR-594 SSH host key storage and retrieval

### DIFF
--- a/lib/provisioner/plugin/automator.rb
+++ b/lib/provisioner/plugin/automator.rb
@@ -70,9 +70,9 @@ module Coopr
 
       def verify_ssh_host_key(host, type = 'rsa')
         log.debug "Verifying SSH host key for #{@task['config']['hostname']}/#{host}"
-        if @task['config']['keys'][type]
+        if @task['config']['ssh_host_keys'][type]
           message = "SSH host key verification failed for #{@task['config']['hostname']}/#{host}"
-          fail message unless @task['config']['keys'][type] == ssh_keyscan(host, type)
+          fail message unless @task['config']['ssh_host_keys'][type] == ssh_keyscan(host, type)
           return true
         else
           message = "SSH Host key not stored for #{@task['config']['hostname']}... Skipping verification"

--- a/lib/provisioner/plugin/automator.rb
+++ b/lib/provisioner/plugin/automator.rb
@@ -79,7 +79,6 @@ module Coopr
           log.warn message
           return true
         end
-        return false
       end
 
       def bootstrap(inputmap)

--- a/lib/provisioner/plugin/automator.rb
+++ b/lib/provisioner/plugin/automator.rb
@@ -43,22 +43,22 @@ module Coopr
         when 'bootstrap'
           bootstrap('hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth)
           return @result
-        when "install"
+        when 'install'
           install({'hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth, 'fields' => fields})
           return @result
-        when "configure"
+        when 'configure'
           configure({'hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth, 'fields' => fields})
           return @result
-        when "initialize"
+        when 'initialize'
           init({'hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth, 'fields' => fields})
           return @result
-        when "start"
+        when 'start'
           start({'hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth, 'fields' => fields})
           return @result
-        when "stop"
+        when 'stop'
           stop({'hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth, 'fields' => fields})
           return @result
-        when "remove"
+        when 'remove'
           remove({'hostname' => hostname, 'ipaddress' => ipaddress, 'sshauth' => sshauth, 'fields' => fields})
           return @result
         else

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -54,7 +54,7 @@ module Coopr
         # TODO: find a way to do this in Ruby
         key = `ssh-keyscan -t #{type} #{host} 2>&1 | grep #{keytype}`.split(' ')
         # Bad key type == "unknown key type #{type}"
-        fail "Unknown SSH Key Type: #{type}" if key[2] == 'type'
+        fail "Unknown SSH Key Type: #{type}" if key[2] == 'type' || key[2].nil?
         return key[2]
       end
 

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -49,9 +49,9 @@ module Coopr
       end
 
       def ssh_keyscan(host, type = 'rsa')
-        _type = type == 'dsa' ? 'dss' : type
+        keytype = type == 'dsa' ? 'dss' : type
         # TODO: find a way to do this in Ruby
-        key = `ssh-keyscan -t #{type} #{host} 2>&1 | grep #{_type}`.split(' ')
+        key = `ssh-keyscan -t #{type} #{host} 2>&1 | grep #{keytype}`.split(' ')
         return key[2]
       end
 

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -48,6 +48,13 @@ module Coopr
         end
       end
 
+      def ssh_keyscan(host, type = 'rsa')
+        _type = type == 'dsa' ? 'dss' : type
+        # TODO: find a way to do this in Ruby
+        key = `ssh-keyscan -t #{type} #{host} 2>&1 | grep #{_type}`.split(' ')
+        return key[2]
+      end
+
       # Utility method to run a command over ssh
       def ssh_exec!(ssh, command, message = command, pty = false)
         stdout_data = ''

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -48,6 +48,7 @@ module Coopr
         end
       end
 
+      # Gets a host's SSH host key
       def ssh_keyscan(host, type = 'rsa')
         keytype = type == 'dsa' ? 'dss' : type
         # TODO: find a way to do this in Ruby

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -53,6 +53,8 @@ module Coopr
         keytype = type == 'dsa' ? 'dss' : type
         # TODO: find a way to do this in Ruby
         key = `ssh-keyscan -t #{type} #{host} 2>&1 | grep #{keytype}`.split(' ')
+        # Bad key type == "unknown key type #{type}"
+        fail "Unknown SSH Key Type: #{type}" if key[2] == 'type'
         return key[2]
       end
 

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -130,7 +130,7 @@ class FogProviderAWS < Coopr::Plugin::Provider
         'bind_v4' => bind_ip
       }
       @result['hostname'] = hostname
-      @result['keys'] = {
+      @result['ssh_host_keys'] = {
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -130,6 +130,9 @@ class FogProviderAWS < Coopr::Plugin::Provider
         'bind_v4' => bind_ip
       }
       @result['hostname'] = hostname
+      @result['keys'] = {
+        'rsa' => ssh_keyscan(bootstrap_ip)
+      }
       # do we need sudo bash?
       sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -129,6 +129,9 @@ class FogProviderDigitalOcean < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bootstrap_ip
       }
+      @result['keys'] = {
+        'rsa' => ssh_keyscan(bootstrap_ip)
+      }
       # do we need sudo bash?
       sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -129,7 +129,7 @@ class FogProviderDigitalOcean < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bootstrap_ip
       }
-      @result['keys'] = {
+      @result['ssh_host_keys'] = {
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -153,7 +153,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
         'bind_v4' => bind_ip
       }
       @result['hostname'] = hostname
-      @result['keys'] = {
+      @result['ssh_host_keys'] = {
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -153,10 +153,11 @@ class FogProviderGoogle < Coopr::Plugin::Provider
         'bind_v4' => bind_ip
       }
       @result['hostname'] = hostname
-
+      @result['keys'] = {
+        'rsa' => ssh_keyscan(bootstrap_ip)
+      }
       # do we need sudo bash?
       sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
-
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -105,6 +105,9 @@ class FogProviderJoyent < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bootstrap_ip
       }
+      @result['keys'] = {
+        'rsa' => ssh_keyscan(bootstrap_ip)
+      }
       # do we need sudo bash?
       sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -105,7 +105,7 @@ class FogProviderJoyent < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bootstrap_ip
       }
-      @result['keys'] = {
+      @result['ssh_host_keys'] = {
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -123,7 +123,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bind_ip
       }
-      @result['keys'] = {
+      @result['ssh_host_keys'] = {
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -123,6 +123,9 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bind_ip
       }
+      @result['keys'] = {
+        'rsa' => ssh_keyscan(bootstrap_ip)
+      }
       # do we need sudo bash?
       sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -110,7 +110,7 @@ class FogProviderRackspace < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bootstrap_ip
       }
-      @result['keys'] = {
+      @result['ssh_host_keys'] = {
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -110,6 +110,9 @@ class FogProviderRackspace < Coopr::Plugin::Provider
         'access_v4' => bootstrap_ip,
         'bind_v4' => bootstrap_ip
       }
+      @result['keys'] = {
+        'rsa' => ssh_keyscan(bootstrap_ip)
+      }
       # do we need sudo bash?
       sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])


### PR DESCRIPTION
This is the initial version of the SSH host key storage and retrieval for Coopr. Currently, the provider plugins are responsible for publishing these keys in the result of a confirm task. As such, the verification is a WARN when the data is missing for a host. All shipped plugins provide this data, but external user plugins may not.
