### PR TITLE
Feature/google disk timeout

### DIFF
--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -264,6 +264,7 @@ module Coopr
           response = _poll_server
           if response.code == 200 && response.to_str && response.to_str != ''
             task = JSON.parse(response.to_str)
+            log.debug "Received task from server <#{response.to_str}>"
             break task
           elsif response.code == 204
             sleep poll_interval

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -26,8 +26,14 @@ class FogProviderGoogle < Coopr::Plugin::Provider
   # plugin defined resources
   @p12_key_dir = 'api_keys'
   @ssh_key_dir = 'ssh_keys'
+
+  # Set Fog timeouts
+  @server_confirm_timeout = 600
+  @disk_confirm_timeout = 120
+
   class << self
     attr_accessor :p12_key_dir, :ssh_key_dir
+    attr_accessor :server_confirm_timeout, :disk_confirm_timeout
   end
 
   def create(inputmap)
@@ -119,7 +125,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       # Wait until the server is ready
       fail "Server #{server.name} is in ERROR state" if server.state == 'ERROR'
       log.debug "Waiting for server to come up: #{providerid}"
-      server.wait_for(600) { ready? }
+      server.wait_for(self.class.server_confirm_timeout) { ready? }
 
       # Get domain name by dropping first dot
       domainname = @task['config']['hostname'].split('.').drop(1).join('.')
@@ -357,7 +363,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
 
   def confirm_disk(name)
     disk = connection.disks.get(name)
-    disk.wait_for(120) { disk.ready? }
+    disk.wait_for(self.class.disk_confirm_timeout) { disk.ready? }
     disk.reload
     disk
   end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -288,7 +288,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
           begin
             disk.destroy(false) # async = false
           rescue Fog::Errors::NotFound
-            log.debug 'Disk not found'
+            log.debug "Disk #{disk.name} not found"
           end
         end
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -263,8 +263,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       # delete server, if it exists
       unless server.nil?
         begin
-          server.destroy
-          server.wait_for(120) { !ready? }
+          server.destroy(false) # async = false
         rescue Fog::Errors::NotFound
           # ok, can be thrown by wait_for
           log.debug 'Server no longer found'
@@ -281,20 +280,10 @@ class FogProviderGoogle < Coopr::Plugin::Provider
         existing_disks.each do |disk|
           log.debug "Issuing delete for disk #{disk.name}"
           begin
-            disk.destroy
+            disk.destroy(false) # async = false
           rescue Fog::Errors::NotFound
-            log.debug 'Disk already deleted'
+            log.debug 'Disk not found'
           end
-        end
-
-        # confirm all disks deleted
-        existing_disks.each do |disk|
-          begin
-            disk.wait_for(120) { !ready? }
-          rescue Fog::Errors::NotFound
-            log.debug "Disk #{disk.name} no longer found"
-          end
-          log.debug "Disk #{disk.name} deleted"
         end
       end
 

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -303,7 +303,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       @result['status'] = 0
     rescue Fog::Errors::Error => e
       log.error('Unable to delete specified components: ' + e.inspect)
-      @result['stderr'] = "Unable to delete specified components: ' + e.inspect"
+      @result['stderr'] = "Unable to delete specified components: #{e.inspect}"
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.delete: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.delete: #{e.inspect}"

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -22,7 +22,6 @@ require 'resolv'
 # top level class for interacting with Google via Fog
 class FogProviderGoogle < Coopr::Plugin::Provider
   include FogProvider
-  #include Coopr::Logging
 
   # plugin defined resources
   @p12_key_dir = 'api_keys'


### PR DESCRIPTION
- [x] A significant change to the google delete logic.  Before, we were (unknowingly) requesting asynchronous deletes, and then relying on our "delete confirmation" methods to account for the inevitable "disk still attached to server" errors.  With this PR, we are requesting deletes syncronously, for which Fog will wait until either a success or error.  We no longer need our own confirmations, and can rely on coopr retries.  In my tests, I have not seen a 'disk still attached error' and deletes fully succeed on first attempt.
- [x] putting the hard-coded confirm timeouts as variables at the top at least
- [x] some misc logging fixes
