### PR TITLE
disable selinux for aws fog provider

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -240,6 +240,13 @@ class FogProviderAWS < Coopr::Plugin::Provider
           ssh_exec!(ssh, "#{sudo} sed -i -e 's:/mnt:/data:' /etc/fstab", 'Updating /etc/fstab for /data')
         end
       end
+
+      # disable SELinux
+      Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
+        cmd = "if test -x /usr/sbin/sestatus ; then #{sudo} /usr/sbin/sestatus | grep disabled || ( test -x /usr/sbin/setenforce && #{sudo} /usr/sbin/setenforce Permissive ) ; fi"
+        ssh_exec!(ssh, cmd, 'Disabling SELinux')
+      end
+
       # Return 0
       @result['status'] = 0
     rescue Fog::Errors::TimeoutError


### PR DESCRIPTION
disable SELinux for AWS, carried over from the google provider
