### PR TITLE
Hotfix/coopr 705 sudo fix2

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -38,10 +38,12 @@ unless node['base'].key?('no_users') && node['base']['no_users'].to_s == 'true'
   %w(chef-solo-search users::sysadmins).each do |cb|
     include_recipe cb
   end
-  begin
-    search('users', 'groups:sysadmins AND NOT action:remove')
-    include_recipe 'sudo' unless node['base'].key?('no_sudo') && node['base']['no_sudo'].to_s == 'true'
-  rescue
+  defined_users = search('users', 'groups:sysadmin AND NOT action:remove')
+  if defined_users.empty?
     Chef::Log.warn('No users defined in group sysadmins, skipping sudo')
+  elsif node['base'].key?('no_sudo') && node['base']['no_sudo'].to_s == 'true'
+    Chef::Log.info('Skipping sudo due to no_sudo attribute')
+  else
+    include_recipe 'sudo'
   end
 end

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -34,6 +34,8 @@ end
 include_recipe 'ulimit::default'
 
 # Add users in the sysadmins group and give them sudo access
+# WARNING - Any user management done here must include any users defined in the Coopr Providers, or not interfere with
+#   their sudo permissions
 unless node['base'].key?('no_users') && node['base']['no_users'].to_s == 'true'
   %w(chef-solo-search users::sysadmins).each do |cb|
     include_recipe cb

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -38,5 +38,10 @@ unless node['base'].key?('no_users') && node['base']['no_users'].to_s == 'true'
   %w(chef-solo-search users::sysadmins).each do |cb|
     include_recipe cb
   end
-  include_recipe 'sudo' unless node['base'].key?('no_sudo') && node['base']['no_sudo'].to_s == 'true'
+  begin
+    search('users', 'groups:sysadmins AND NOT action:remove')
+    include_recipe 'sudo' unless node['base'].key?('no_sudo') && node['base']['no_sudo'].to_s == 'true'
+  rescue
+    Chef::Log.warn('No users defined in group sysadmins, skipping sudo')
+  end
 end

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -34,6 +34,9 @@ end
 include_recipe 'ulimit::default'
 
 # Add users in the sysadmins group and give them sudo access
-%w(chef-solo-search sudo users::sysadmins).each do |cb|
-  include_recipe cb unless node['base'].key?("no_#{cb}") && node['base']["no_#{cb}"].to_s == 'true'
+unless node['base'].key?('no_users') && node['base']['no_users'].to_s == 'true'
+  %w(chef-solo-search users::sysadmins).each do |cb|
+    include_recipe cb
+  end
+  include_recipe 'sudo' unless node['base'].key?('no_sudo') && node['base']['no_sudo'].to_s == 'true'
 end


### PR DESCRIPTION
- [x] `coopr_base` will include the `sudo` recipe only if users are found via a chef_solo_search.  This is to prevent the scenario where using a vanilla standalone with no users, `coopr_base` could interfere with sudo access
  - [x] warning to try to express how this can be dangerous
