### PR TITLE
Use Google recommended minimum of 200G for performance

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -238,7 +238,7 @@
           "google_data_disk_size_gb": {
             "label": "Data disk size in GB",
             "type": "text",
-            "default": 10,
+            "default": 200,
             "override": true,
             "tip": "Size of the persistent data disk to be created and mounted"
           },


### PR DESCRIPTION
When creating a disk less than 200G, GCE gives a warning about reduced performance. Reduced performance is bad... mmm'kay?
