### PR TITLE
explicitly set priorities to enforce /etc/hosts ordering

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_hosts/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_hosts/recipes/default.rb
@@ -24,6 +24,7 @@ node['coopr']['cluster']['nodes'].each do |n, v|
     hostname v.hostname
     aliases [ short_host ]
     unique true
+    priority 62
     action :create
   end
   next unless v.key?('ipaddresses') && v['ipaddresses'].key?('bind_v4')
@@ -31,6 +32,7 @@ node['coopr']['cluster']['nodes'].each do |n, v|
   hostsfile_entry v['ipaddresses']['bind_v4'] do
     hostname v.hostname
     aliases [ short_host ]
+    priority 61
     action :create
   end
 end


### PR DESCRIPTION
Fixes https://issues.cask.co/browse/COOPR-718
- [x] updates `coopr_hosts` to set explicit priorities on public/private IPs when calling `hostsfile`'s LWRP
- [x] see https://github.com/customink-webops/hostsfile/blob/master/libraries/entry.rb#L162
- [x] it will now order all public ips ahead of private.  example hosts file for 3-node cluster:

```
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
104.154.65.190  190.65.154.104.bc.googleusercontent.com 190 # @62
104.154.69.44   44.69.154.104.bc.googleusercontent.com 44   # @62
23.251.157.88   88.157.251.23.bc.googleusercontent.com 88   # @62
10.240.92.94    190.65.154.104.bc.googleusercontent.com 190 # @61
10.240.0.81 44.69.154.104.bc.googleusercontent.com 44   # @61
10.240.165.46   88.157.251.23.bc.googleusercontent.com 88   # @61
::1 localhost localhost.localdomain localhost6 localhost6.localdomain6
```
