### PR TITLE
Feature/gce fix retry

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -103,7 +103,6 @@ class FogProviderGoogle < Coopr::Plugin::Provider
     rescue => e
       log.error('Unexpected Error Occurred in FogProviderGoogle.create: ' + e.inspect)
       @result['stderr'] = "Unexpected Error Occurred in FogProviderGoogle.create: #{e.inspect}"
-
       # delete any disks created
       @disks.each do |orphan_disk|
         begin

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -356,7 +356,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
     disk = connection.disks.get(name)
     unless disk.nil?
       # disk of requested name exists already
-      existing_size_gb = disk.size_gb.to_i
+      existing_size_gb = disk.size_gb.nil? ? nil : disk.size_gb.to_i
       existing_zone_name = disk.zone_name.nil? ? nil : disk.zone_name.split('/').last
       existing_source_image = disk.source_image.nil? ? nil : disk.source_image.split('/').last
       if size_gb == existing_size_gb && zone_name == existing_zone_name && source_image == existing_source_image


### PR DESCRIPTION
fixes existing CREATE retry logic on google.  Incorrect comparison would never recognize an existing disk from previous retry.  This code path initially is unlikely (but possible) to be used since #53 deletes any disks on a failure, but this fixes the existing code.
