### PR TITLE
Update GCE zones to include europe-west1-c and europe-west1-d

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -257,6 +257,8 @@
               "asia-east1-c",
               "europe-west1-a",
               "europe-west1-b",
+              "europe-west1-c",
+              "europe-west1-d",
               "us-central1-a",
               "us-central1-b",
               "us-central1-f"


### PR DESCRIPTION
These are new zones in Google and should be exposed to the user.
