### PR TITLE
fix_shell_automator_bootstrap

### DIFF
--- a/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -47,8 +47,10 @@ class ShellAutomator < Coopr::Plugin::Automator
     # name of tarball to generate
     @lib_tar = %W[ #{work_dir} #{tenant} automatortypes shell lib.tar.gz ].join('/')
 
+    #remote coopr directory
+    @remote_coopr_dir = "/var/cache/coopr"
     # remote storage directory
-    @remote_cache_dir = "/var/cache/coopr/shell_automator"
+    @remote_cache_dir = "#{@remote_coopr_dir}/shell_automator"
     # remote script location to be exported in $PATH
     @remote_scripts_dir = "#{@remote_cache_dir}/scripts"
     # remote lib location
@@ -197,6 +199,7 @@ class ShellAutomator < Coopr::Plugin::Automator
     begin
       Net::SSH.start(ipaddress, sshauth['user'], @credentials) do |ssh|
         ssh_exec!(ssh, "#{sudo} mkdir -p #{@remote_cache_dir}", "Creating remote cache dir")
+        ssh_exec!(ssh,"#{sudo} chmod a+x #{remote_coopr_dir}","Granting execute permissions on #{remote_coopr_dir}")
         ssh_exec!(ssh, "#{sudo} chown -R #{sshauth['user']} #{@remote_cache_dir}", "Changing cache dir owner to #{sshauth['user']}")
       end
     rescue Net::SSH::AuthenticationFailed


### PR DESCRIPTION
Split the remote cache directory into a parent(remote_coopr_dir) and a child directory(remote_cache_dir) to allow delivering execute permission on the parent directory and change the ownership on the child directory.

Else, with the current code where we merely deliver ownership of the remote_cache_dir to the server user while not providing execute permissions on the parent directory; thus failing the scp operation during  the bootstrap.
