### PR TITLE
data-uploader improved validation and error reporting

### DIFF
--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -153,7 +153,13 @@ module Coopr
         uri = %W( #{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]}).join('/')
         resp = Coopr::RestHelper.get(uri, @headers)
         if resp.code == 200
-          resp_plugin = JSON.parse(resp.to_str)
+          begin
+            resp_plugin = JSON.parse(resp.to_str)
+          rescue JSON::ParserError => e
+            fail "Error parsing response from server #{@options[:uri]}: #{e.class}. " \
+                 "content-type #{resp.headers[:content_type]}\n" \
+                 "Are you connecting to the right server:port?\n"
+          end
           if resp_plugin.key?('resourceTypes') && resp_plugin['resourceTypes'].key?(@options[:resource_type])
             resp_resource = resp_plugin['resourceTypes'][@options[:resource_type]]
             if resp_resource.key?('format')

--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -319,7 +319,8 @@ begin
     ldr.sync
   end
 rescue ArgumentError => e
-  puts op # prints usage
+  puts "Argument Error: #{e.message}"
+  puts "run with  -h or --help to get usage help"
   exit 1
 rescue => e
   puts "Error: #{e.message} #{e.backtrace}"


### PR DESCRIPTION
Using the data-uploader can be confusing if the actual validation errors are not printed.
Also confusing is when mixing ports (API with UI) the data-uploader will blurt the HTML response from UI endpoint when it fails to parse it at JSON.

Although I was able to upload keys to server eventually, the cluster creation still failed, again without any clues, but unfortunately I'll have to stop my debugging here.

I think validation and error reporting (especially in the UI) should get more attention it's merely impossible to use without intimate knowledge of the implementation and debugging. 
