### PR TITLE
Remove europe-west1-a from GCE, as it's no longer available

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -255,7 +255,6 @@
               "asia-east1-a",
               "asia-east1-b",
               "asia-east1-c",
-              "europe-west1-a",
               "europe-west1-b",
               "europe-west1-c",
               "europe-west1-d",


### PR DESCRIPTION
Prevents users from getting errors on provision.
