### PR TITLE
Constrain net-ssh gem

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -21,5 +21,5 @@
 source 'https://rubygems.org'
 
 gem 'fog', '~> 1.26.0'
-gem 'net-ssh'
+gem 'net-ssh', '~> 2.6'
 gem 'google-api-client', '~> 0.6', '>= 0.6.2'


### PR DESCRIPTION
Otherwise, bundle install fails on Ruby 1.9 due to net-ssh 3.0+ requiring Ruby 2.0+
