### PR TITLE
COOPR-788 Ping check to opscode.com fails

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -324,12 +324,12 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
 
         # determine if curl is installed, else default to wget
         chef_version = '11.16.4'
-        chef_install_cmd = "curl -L https://www.opscode.com/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
+        chef_install_cmd = "curl -L https://www.chef.io/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
         begin
           ssh_exec!(ssh, 'which curl', 'Checking for curl')
         rescue CommandExecutionError
           log.debug 'curl not found, defaulting to wget'
-          chef_install_cmd = "wget -qO - https://www.opscode.com/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
+          chef_install_cmd = "wget -qO - https://www.chef.io/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
         end
         ssh_exec!(ssh, chef_install_cmd, 'Installing Chef')
       end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -153,7 +153,7 @@ class FogProviderAWS < Coopr::Plugin::Provider
 
       # Validate connectivity
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, 'ping -c1 www.google.com', 'Validating external connectivity and DNS resolution via ping')
         ssh_exec!(ssh, "#{sudo} hostname #{hostname}", "Setting hostname to #{hostname}")
         # Setting up disks
         log.debug 'Starting disk configuration'

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -152,7 +152,7 @@ class FogProviderDigitalOcean < Coopr::Plugin::Provider
 
       # Validate connectivity
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, 'ping -c1 www.digitalocean.com', 'Validating external connectivity and DNS resolution via ping')
       end
       # Return 0
       @result['status'] = 0

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -199,7 +199,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       # Validate connectivity
       log.debug "Attempting to ssh to #{bootstrap_ip} as #{@task['config']['ssh-auth']['user']} with credentials: #{@credentials}"
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, 'ping -c1 www.google.com', 'Validating external connectivity and DNS resolution via ping')
         ssh_exec!(ssh, "#{sudo} hostname #{hostname}", "Setting hostname to #{hostname}")
       end
 

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -130,7 +130,7 @@ class FogProviderJoyent < Coopr::Plugin::Provider
 
       # Validate connectivity
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, 'ping -c1 www.joyent.com', 'Validating external connectivity and DNS resolution via ping')
         ssh_exec!(ssh, "#{sudo} hostname #{@task['config']['hostname']}", 'Temporarily setting hostname')
         # Check and make sure firstboot is done running
         beginning = Time.now

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -146,7 +146,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
 
       # Validate connectivity
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, 'ping -c1 www.google.com', 'Validating external connectivity and DNS resolution via ping')
       end
       # Return 0
       @result['status'] = 0

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -133,7 +133,7 @@ class FogProviderRackspace < Coopr::Plugin::Provider
 
       # Validate connectivity and Mount data disk
       Net::SSH.start(bootstrap_ip, @task['config']['ssh-auth']['user'], @credentials) do |ssh|
-        ssh_exec!(ssh, 'ping -c1 www.opscode.com', 'Validating external connectivity and DNS resolution via ping')
+        ssh_exec!(ssh, 'ping -c1 www.rackspace.com', 'Validating external connectivity and DNS resolution via ping')
         ssh_exec!(ssh, "test -e /dev/xvde1 && (#{sudo} /sbin/mkfs.ext4 /dev/xvde1 && #{sudo} mkdir -p /data && #{sudo} mount /dev/xvde1 /data) || true", 'Mounting any additional data disks')
       end
       # Return 0


### PR DESCRIPTION
fixes https://issues.cask.co/browse/COOPR-788.
- [x] ping the corresponding provider website to validate connectivity.  exception for openstack: ping google, exception for aws: ping google (amazon blocks ICMP)
- [x] update the omnibus installer url in chef-solo automator (this currently still redirects, but who knows for how much longer)
