### PR TITLE
Update fog to 1.36.0 for DigitalOcean v2 API support

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -20,6 +20,6 @@
 
 source 'https://rubygems.org'
 
-gem 'fog', '~> 1.26.0'
+gem 'fog', '~> 1.36.0'
 gem 'net-ssh', '~> 2.6'
 gem 'google-api-client', '~> 0.6', '>= 0.6.2'


### PR DESCRIPTION
Use latest released version of fog Gem to support DigitalOcean V2 API.
