### PR TITLE
Chef 11.16.4 fails on source_url and issues_url

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/cdap/metadata.rb
@@ -15,6 +15,3 @@ depends 'krb5_utils'
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os
 end
-
-source_url 'https://github.com/caskdata/cdap_cookbook'
-issues_url 'https://issues.cask.co/browse/COOK/component/10603'


### PR DESCRIPTION
Remove them from the metadata.
