### PR TITLE
Support common set of packages to install on all platforms

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/attributes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/attributes/default.rb
@@ -1,3 +1,25 @@
+#
+# Cookbook Name:: coopr_packages
+# Attribute:: default
+#
+# Copyright © 2013-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['coopr_packages']['common']['install'] = []
+default['coopr_packages']['common']['upgrade'] = []
+default['coopr_packages']['common']['remove'] = []
 default['coopr_packages']['debian']['install'] = []
 default['coopr_packages']['debian']['upgrade'] = []
 default['coopr_packages']['debian']['remove'] = []

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Removes a defined set of packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.1'
+version '0.0.2'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -18,7 +18,7 @@
 #
 
 # Install common packages
-%w(install upgrade remove).each do |act|
+%w(remove install upgrade).each do |act|
   node['coopr_packages']['common'][act].each do |cb|
     package cb do
       action act.to_sym
@@ -28,7 +28,7 @@ end
 
 # Install platform-specific packages
 pf = node['platform_family']
-%w(install upgrade remove).each do |act|
+%w(remove install upgrade).each do |act|
   node['coopr_packages'][pf][act].each do |cb|
     package cb do
       action act.to_sym

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: coopr_packages
 # Recipe:: default
 #
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,16 @@
 # limitations under the License.
 #
 
+# Install common packages
+%w(install upgrade remove).each do |act|
+  node['coopr_packages']['common'][act].each do |cb|
+    package cb do
+      action act.to_sym
+    end
+  end
+end
+
+# Install platform-specific packages
 pf = node['platform_family']
 %w(install upgrade remove).each do |act|
   node['coopr_packages'][pf][act].each do |cb|
@@ -26,6 +36,7 @@ pf = node['platform_family']
   end
 end
 
+# Upgrade packages
 case pf
 when 'debian'
   execute 'update-apt-packages' do


### PR DESCRIPTION
This allows listing packages which have a common name across all supported platforms, such as `git` or `curl`, without having to specify them for each platform.
