### PR TITLE
Run packages, hosts, dns, then firewall

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Base settings for all hosts'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.1'
+version '0.1.2'
 
 depends 'coopr_dns'
 depends 'coopr_firewall'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -26,7 +26,7 @@ when 'rhel'
 end
 
 # We always run our dns, firewall, hosts, and packages cookbooks
-%w(dns firewall hosts packages).each do |cb|
+%w(packages hosts dns firewall).each do |cb|
   include_recipe "coopr_#{cb}::default" unless node['base'].key?("no_#{cb}") && node['base']["no_#{cb}"].to_s == 'true'
 end
 


### PR DESCRIPTION
This ensures any packages necessary for updating DNS are available. It also puts hosts before DNS, in case it requires a configured local `/etc/hosts` hostname, and puts both before firewall, which could be a consumer of either sets of hostnames.
