### PR TITLE
COOPR-784 Relax DockerAutomator search requirements

### DIFF
--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -75,7 +75,8 @@ class DockerAutomator < Coopr::Plugin::Automator
     when 0
       fail "Image #{image_name} not found!"
     else
-      fail "More than one image found for #{image_name}!"
+      log.debug "More than one image found for #{image_name}!"
+      return true
     end
   end
 


### PR DESCRIPTION
This allows for using image names, such as `cassandra` which have more than one search response.

Fixes [COOPR-784](https://issues.cask.co/browse/COOPR-784)
