### PR TITLE
COOPR-787 Support command line arguments

### DIFF
--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
@@ -21,7 +21,7 @@
             "tip": "Comma-separated list of container ports to publish"
           },
           "command": {
-            "label": "Command to run, including arguments",
+            "label": "Docker CMD to run, including arguments",
             "override": true,
             "type": "text",
             "tip": "Command to append to \"docker run\" command line"

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
@@ -16,9 +16,15 @@
           },
           "publish_ports": {
             "label": "Container ports to publish",
-            "override": false,
+            "override": true,
             "type": "text",
             "tip": "Comma-separated list of container ports to publish"
+          },
+          "command": {
+            "label": "Command to run, including arguments",
+            "override": true,
+            "type": "text",
+            "tip": "Command to append to \"docker run\" command line"
           }
         },
         "required": [


### PR DESCRIPTION
This exposes a new "command" attribute for services using this automator, which is user overridable. Also, since it is now possible for users to send arguments which could change ports, I have made the port mapping overridable.
