### PR TITLE
COOPR-801 Allow specifying host-side ports

### DIFF
--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
@@ -12,19 +12,19 @@
             "label": "Image Name",
             "override": false,
             "type": "text",
-            "tip": "The Image name on Docker Hub"
+            "tip": "Image name in NAME[:TAG] format"
           },
           "publish_ports": {
             "label": "Container ports to publish",
             "override": true,
             "type": "text",
-            "tip": "Comma-separated list of container ports to publish"
+            "tip": "Comma-separated list of local:container or just container ports to publish"
           },
           "command": {
-            "label": "Docker CMD to run, including arguments",
+            "label": "Docker CMD",
             "override": true,
             "type": "text",
-            "tip": "Command to append to \"docker run\" command line"
+            "tip": "Docker CMD to append to \"docker run\" command line, including arguments"
           }
         },
         "required": [

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -89,7 +89,13 @@ class DockerAutomator < Coopr::Plugin::Automator
     ports = @task['config']['ports'] ? @task['config']['ports'] : []
     # TODO: check for port conflicts and error
     @fields['publish_ports'].split(',').each do |port|
-      portmap = "#{portmap}-p #{port}:#{port} " # extra space at end
+      if port.include?(':') # Mapping is host:container
+        portmap = "#{portmap}-p #{port} " # extra space at end
+      else
+        portmap = "#{portmap}-p #{port}:#{port} " # extra space at end
+      end
+      # Drop container-side port, if specified
+      port = port.split(':').first
       if !ports.nil? && ports.include?(port)
         raise "Port #{port} already in use on this host!"
       else


### PR DESCRIPTION
This allows us to specify a complete port mapping to a given Docker container. I have also retained backwards-compatibility as a usability shortcut for specifying the same host:container port.

Valid:

```
8080:8100
8080:8100,55054
8100,55054
```

Invalid:

```
8080:
:8100
8080:,55054
```

This can be used to avoid potential port conflicts, since the DockerAutomator ensures that the host-side port is not already in use by another container (if provisioned with Coopr)...
