### PR TITLE
Install updated centos-release-scl (conditionally)

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Base settings for all hosts'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.0'
+version '1.0.1'
 
 depends 'coopr_dns'
 depends 'coopr_firewall'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -23,6 +23,11 @@ when 'debian'
   include_recipe 'apt::default'
 when 'rhel'
   include_recipe 'yum-epel::default' if node['coopr_base']['use_epel'].to_s == 'true'
+  # The SCL repository has moved... temporary workaround
+  yum_package 'centos-release-scl' do
+    action :install
+    only_if 'yum list installed | grep centos-release-SCL'
+  end
 end
 
 # We always run our dns, firewall, hosts, and packages cookbooks


### PR DESCRIPTION
Currently, some Google images (and possibly others) are using the `centos-release-SCL` package to install this repository. It has recently been updated to `centos-release-scl` and the repository name has changed.
