### PR TITLE
COOPR-802 Update Chef to Chef 12

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -323,7 +323,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
         end
 
         # determine if curl is installed, else default to wget
-        chef_version = '11.16.4'
+        chef_version = '12.4.3'
         chef_install_cmd = "curl -L https://www.chef.io/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
         begin
           ssh_exec!(ssh, 'which curl', 'Checking for curl')


### PR DESCRIPTION
Use Chef 12.4.3, which was the last release before Chef 12.5 which introduced a new resources system.
