### PR TITLE
delete old SCL repo definition at compile time

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_base/recipes/default.rb
@@ -22,6 +22,10 @@ case node['platform_family']
 when 'debian'
   include_recipe 'apt::default'
 when 'rhel'
+  # The SCL repository has moved... temporary workaround
+  r = yum_repository('CentOS-SCL') { action :nothing }
+  r.run_action( :delete)
+
   include_recipe 'yum-epel::default' if node['coopr_base']['use_epel'].to_s == 'true'
   # The SCL repository has moved... temporary workaround
   yum_package 'centos-release-scl' do


### PR DESCRIPTION
Centos SCL repository has been replaced.  https://github.com/caskdata/coopr-provisioner/pull/118 adds the replacement package.  this removes the old definition
