### PR TITLE
Reduce cache time for tarballs to 1 minute

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -49,9 +49,9 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
       return
     end
 
-    # limit tarball regeneration to once per 10min
+    # limit tarball regeneration to once per min
     # rubocop:disable GuardClause
-    if !File.exist?(chef_primitive_tar) || ((Time.now - File.stat(chef_primitive_tar).mtime).to_i > 600)
+    if !File.exist?(chef_primitive_tar) || ((Time.now - File.stat(chef_primitive_tar).mtime).to_i > 60)
       log.debug "Generating #{chef_primitive_tar} from #{chef_primitive_path}"
       `tar -chzf "#{chef_primitive_tar}.new" #{chef_primitive}`
       `mv "#{chef_primitive_tar}.new" "#{chef_primitive_tar}"`


### PR DESCRIPTION
This serves the original purpose of preventing the tarball creation on every task while still providing timely updates.
