### PR TITLE
COOPR-803 Support Docker -e, --link, -v

### DIFF
--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
@@ -14,6 +14,24 @@
             "type": "text",
             "tip": "Image name in NAME[:TAG] format"
           },
+          "environment_variables": {
+            "label": "Environment variables",
+            "override": true,
+            "type": "text",
+            "tip": "Comma-separated list of environment variables/values to set within container"
+          },
+          "links": {
+            "label": "Links to containers",
+            "override": true,
+            "type": "text",
+            "tip": "Comma-separated list of links to another container"
+          },
+          "volumes": {
+            "label": "Volumes to mount into container",
+            "override": true,
+            "type": "text",
+            "tip": "Comma-separated list of local:container volumes to bind mount"
+          },
           "publish_ports": {
             "label": "Container ports to publish",
             "override": true,

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -107,31 +107,19 @@ class DockerAutomator < Coopr::Plugin::Automator
   end
 
   def envmap
-    envmap = ''
     # TODO: allow commas inside quotes
-    @fields['environment_variables'].split(',').each do |env|
-      envmap = "#{envmap}-e #{env} "
-    end
-    envmap
+    @fields['environment_variables'].split(',').map {|x| "-e #{x}" }.join(' ')
   end
 
   def linkmap
-    linkmap = ''
-    @fields['links'].split(',').each do |link|
-      linkmap = "#{linkmap}--link #{link} "
-    end
-    linkmap
+    @fields['links'].split(',').map {|x| "--link #{x}" }.join(' ')
   end
 
   def volmap
-    volmap = ''
     @fields['volumes'].split(',').each do |vol|
-      volmap = "#{volmap}-v #{vol} "
-      vol.split(':').each do |dir|
-        ::FileUtils.mkdir_p dir
-      end
+      ::FileUtils.mkdir_p vol.split(':').first
     end
-    volmap
+    @fields['volumes'].split(',').map {|x| "-v #{x}" }.join(' ')
   end
 
   def container_name(image_name)

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 #
-# Copyright © 2012-2015 Cask Data, Inc.
+# Copyright © 2012-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -106,9 +106,41 @@ class DockerAutomator < Coopr::Plugin::Automator
     portmap
   end
 
+  def envmap
+    envmap = ''
+    # TODO: allow commas inside quotes
+    @fields['environment_variables'].split(',').each do |env|
+      envmap = "#{envmap}-e #{env} "
+    end
+    envmap
+  end
+
+  def linkmap
+    linkmap = ''
+    @fields['links'].split(',').each do |link|
+      linkmap = "#{linkmap}--link #{link} "
+    end
+    linkmap
+  end
+
+  def volmap
+    volmap = ''
+    @fields['volumes'].split(',').each do |vol|
+      volmap = "#{volmap}-v #{vol} "
+      vol.split(':').each do |dir|
+        ::FileUtils.mkdir_p dir
+      end
+    end
+    volmap
+  end
+
+  def container_name(image_name)
+    "--name coopr-#{image_name.split('/').last}"
+  end
+
   def run_container(image_name, command = nil)
     # TODO: make this smarter (run vs start, etc)
-    docker_command("run -d #{portmap} #{image_name} #{command}")
+    docker_command("run -d #{portmap} #{envmap} #{linkmap} #{volmap} #{container_name(image_name)} #{image_name} #{command}")
   end
 
   def start_container(id)


### PR DESCRIPTION
This adds three new fields to the DockerAutomator-backed services, `environment_variables`, `links`, and `volumes` which map to the appropriate Docker command line options. In the case of volumes, we ensure that the local PATH exists when setting up the container. This also gives predictable names to containers for easier linking.

NOTE: `environment_variables` currently splits on commas and doesn't consider quotes, this should be good for an initial implementation, but this should be resolved... marked TODO
