### PR TITLE
COOPR-805 Run docker commands as sshuser

### DIFF
--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -55,9 +55,13 @@ class DockerAutomator < Coopr::Plugin::Automator
     File.open(outfile, 'wb', mode) { |f| f.write(Base64.decode64(string)) }
   end
 
-  def remote_command(cmd)
-    # do we need sudo bash?
-    sudo = 'sudo' unless @sshuser == 'root'
+  def remote_command(cmd, root=false)
+    sudo =
+      if root == false || @sshuser == 'root'
+        nil
+      else
+        'sudo'
+      end
     Net::SSH.start(@ipaddress, @sshuser, @credentials) do |ssh|
       ssh_exec!(ssh, "#{sudo} #{cmd}", "Running: #{cmd}")
     end
@@ -114,20 +118,33 @@ class DockerAutomator < Coopr::Plugin::Automator
 
   def envmap
     # TODO: allow commas inside quotes
-    @fields['environment_variables'].split(',').map {|x| "-e #{x}" }.join(' ') if @fields.key?('environment_variables')
+    @envs.split(',').map {|x| "-e #{x}" }.join(' ')
   end
 
   def linkmap
-    @fields['links'].split(',').map {|x| "--link #{x}" }.join(' ') if @fields.key?('links')
+    @links.split(',').map {|x| "--link #{x}" }.join(' ')
   end
 
   def volmap
-    @fields['volumes'].split(',').map {|x| "-v #{x}" }.join(' ') if @fields.key?('volumes')
+    @vols.split(',').map {|x| "-v #{x}" }.join(' ')
   end
 
   def container_name(image_name)
     "--name coopr-#{image_name.split('/').last}"
   end
+
+  def setup_host_volumes(volumes)
+    volumes.split(',').each do |vol|
+      # Does the host-side exist, if so, do nothing
+      begin
+        remote_command("test -d #{vol.split(':').first}")
+        continue
+      # Directory doesn't exist, create it and change ownership
+      rescue CommandExecutionError
+        remote_command("mkdir -p #{vol.split(':').first}", true)
+        remote_command("chown -R #{@sshuser} #{vol.split(':').first}", true)
+      end
+    end
 
   def run_container(image_name, command = nil)
     # TODO: make this smarter (run vs start, etc)
@@ -153,6 +170,9 @@ class DockerAutomator < Coopr::Plugin::Automator
     @fields = inputmap['fields']
     @image_name = @fields && @fields.key?('image_name') ? @fields['image_name'].gsub(/\s+/, '') : nil
     @command = @fields && @fields.key?('command') ? @fields['command'] : nil
+    @envs = @fields && @fields.key?('environment_variables') ? @fields['environment_variables'] : nil
+    @links = @fields && @fields.key?('links') ? @fields['links'] : nil
+    @vols = @fields && @fields.key?('volumes') ? @fields['volumes'] : nil
   end
 
   # bootstrap remote machine: check for docker
@@ -180,9 +200,7 @@ class DockerAutomator < Coopr::Plugin::Automator
     parse_inputmap(inputmap)
     write_ssh_file
     log.debug "Attempting ssh into ip: #{@ipaddress}, user: #{@sshuser}"
-    @fields['volumes'].split(',').each do |vol|
-      remote_command("mkdir -p #{vol.split(':').first}")
-    end if @fields.key?('volumes')
+    setup_host_volumes(@vols)
     pull_image(@image_name) if search_image(@image_name)
     @result['status'] = 0
     log.debug "DockerAutomator install completed successfully: #{@result}"

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -118,15 +118,15 @@ class DockerAutomator < Coopr::Plugin::Automator
 
   def envmap
     # TODO: allow commas inside quotes
-    @envs.split(',').map {|x| "-e #{x}" }.join(' ')
+    @envs.map {|x| "-e #{x}" }.join(' ')
   end
 
   def linkmap
-    @links.split(',').map {|x| "--link #{x}" }.join(' ')
+    @links.map {|x| "--link #{x}" }.join(' ')
   end
 
   def volmap
-    @vols.split(',').map {|x| "-v #{x}" }.join(' ')
+    @vols.map {|x| "-v #{x}" }.join(' ')
   end
 
   def container_name(image_name)
@@ -134,15 +134,16 @@ class DockerAutomator < Coopr::Plugin::Automator
   end
 
   def setup_host_volumes(volumes)
-    volumes.split(',').each do |vol|
+    volumes.each do |volume|
+      dir = volume.split(':').first
       # Does the host-side exist, if so, do nothing
       begin
-        remote_command("test -d #{vol.split(':').first}")
+        remote_command("test -d #{dir}")
         continue
       # Directory doesn't exist, create it and change ownership
       rescue CommandExecutionError
-        remote_command("mkdir -p #{vol.split(':').first}", true)
-        remote_command("chown -R #{@sshuser} #{vol.split(':').first}", true)
+        remote_command("mkdir -p #{dir}", true)
+        remote_command("chown -R #{@sshuser} #{dir}", true)
       end
     end
 
@@ -170,9 +171,9 @@ class DockerAutomator < Coopr::Plugin::Automator
     @fields = inputmap['fields']
     @image_name = @fields && @fields.key?('image_name') ? @fields['image_name'].gsub(/\s+/, '') : nil
     @command = @fields && @fields.key?('command') ? @fields['command'] : nil
-    @envs = @fields && @fields.key?('environment_variables') ? @fields['environment_variables'] : nil
-    @links = @fields && @fields.key?('links') ? @fields['links'] : nil
-    @vols = @fields && @fields.key?('volumes') ? @fields['volumes'] : nil
+    @envs = @fields && @fields.key?('environment_variables') ? @fields['environment_variables'].split(',') : []
+    @links = @fields && @fields.key?('links') ? @fields['links'].split(',') : []
+    @vols = @fields && @fields.key?('volumes') ? @fields['volumes'].split(',') : []
   end
 
   # bootstrap remote machine: check for docker

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -136,12 +136,11 @@ class DockerAutomator < Coopr::Plugin::Automator
   def setup_host_volumes(volumes)
     volumes.each do |volume|
       dir = volume.split(':').first
-      # Does the host-side exist, if so, do nothing
       begin
+        # Does the host-side exist, if so, do nothing
         remote_command("test -d #{dir}")
-        continue
-      # Directory doesn't exist, create it and change ownership
       rescue CommandExecutionError
+        # Directory doesn't exist, create it and change ownership
         remote_command("mkdir -p #{dir}", true)
         remote_command("chown -R #{@sshuser} #{dir}", true)
       end


### PR DESCRIPTION
This introduces a couple changes to allow running `docker` commands as non-root users.
- [x] `remote_command` accepts second argument to enable `sudo`
- [x] Initialize `@envs`, `@links`, and `@vols` in `parse_inputmap`
- [x] Move host-side volume management to `setup_host_volumes`
  - [x] Only configure if not existing, already (assumed preconfigured by admin)
  - [x] If we create it, set owner to `@sshuser` for use within Docker containers
- [x] Run `docker` commands as non-root via `docker_command`

This allows non-root users to use the volumes. This wasn't a problem with containers that drop privileges, such as `elasticsearch` or `cassandra`, but causes an issue in containers that maintain their root privileges and allow access from multiple users to the local file-system, such as FTP or SFTP (via `atmoz/sftp` image).

Before:

```
$ sftp -P 2222 foo@REDACTED
foo@REDACTED's password:
Connected to REDACTED.
sftp> ls -l
drwxr-xr-x    2 0        0            4096 Jun  9 16:03 sftp
sftp> cd sftp
sftp> ls -la
drwxr-xr-x    2 0        0            4096 Jun  9 16:03 .
drwxr-xr-x    3 0        0            4096 Jun  9 16:04 ..
sftp> put demo.txt
Uploading demo.txt to /sftp/demo.txt
remote open("/sftp/demo.txt"): Permission denied
sftp> quit
```

After:

```
$ sftp -P 2222 foo@REDACTED
foo@REDACTED's password:
Connected to REDACTED.
sftp> ls -l
drwxr-xr-x    2 1000     0            4096 Jun  9 16:03 sftp
sftp> cd sftp
sftp> ls -al
drwxr-xr-x    2 1000     0            4096 Jun  9 16:03 .
drwxr-xr-x    3 0        0            4096 Jun  9 16:12 ..
sftp> put demo.txt
Uploading demo.txt to /sftp/demo.txt
demo.txt                                                                                          100%  376     0.4KB/s   00:00
sftp> quit
```

This requires the user to create the SFTP user with the same UID as `@sshuser` if the administrator has not preconfigured the volumes with the correct UID mapping and is letting Coopr create them on the Docker host.
