### PR TITLE
COOPR-804 Support resizing root disk on Google

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -249,7 +249,7 @@
             "tip": "Size of the persistent data disk to be created and mounted. Multiple disks can be specified as a comma-separated list"
           },
           "google_root_disk_size_gb": {
-            "label": "Root disk size(s) in GB",
+            "label": "Root disk size in GB",
             "type": "text",
             "default": 10,
             "override": true,

--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -248,6 +248,13 @@
             "override": true,
             "tip": "Size of the persistent data disk to be created and mounted. Multiple disks can be specified as a comma-separated list"
           },
+          "google_root_disk_size_gb": {
+            "label": "Root disk size(s) in GB",
+            "type": "text",
+            "default": 10,
+            "override": true,
+            "tip": "Size of the root disk to be created. Image must support resizing, or you must resize yourself"
+          },
           "zone_name": {
             "label": "Zone",
             "type": "select",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -31,9 +31,6 @@ class FogProviderGoogle < Coopr::Plugin::Provider
   @server_confirm_timeout = 600
   @disk_confirm_timeout = 120
 
-  # Root disk size in GB
-  @root_disk_size = 10
-
   class << self
     attr_accessor :p12_key_dir, :ssh_key_dir
     attr_accessor :server_confirm_timeout, :disk_confirm_timeout
@@ -62,7 +59,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
 
       # disks are managed separately, so CREATE must first create and confirm the disk to be used
       # handle boot disk
-      create_disk(@providerid, @root_disk_size, @zone_name, @image)
+      create_disk(@providerid, @google_root_disk_size_gb, @zone_name, @image)
       disk = confirm_disk(@providerid)
 
       @disks = [disk]


### PR DESCRIPTION
See [COOPR-804](https://issues.cask.co/browse/COOPR-804) for more details/history...

This simply allows us to configure the default root disk's size, rather than hard-coding it to 10GB.
