### PR TITLE
preserve sudo environment with -E flag

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -143,7 +143,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     ipaddress = inputmap['ipaddress']
 
     # do we need sudo bash?
-    sudo = 'sudo' unless sshauth['user'] == 'root'
+    sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
     write_ssh_file
     @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
@@ -244,7 +244,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     jsondata = generate_chef_json_attributes(json_attributes)
 
     # do we need sudo bash?
-    sudo = 'sudo' unless sshauth['user'] == 'root'
+    sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
     write_ssh_file
     @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
@@ -292,7 +292,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     ipaddress = inputmap['ipaddress']
 
     # do we need sudo bash?
-    sudo = 'sudo' unless sshauth['user'] == 'root'
+    sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
     write_ssh_file
     @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?


### PR DESCRIPTION
Attempts to preserve environment variables when running commands.  This is particularly useful if commands are dependent on `http_proxy` variables or similar.

This should really be a plugin configuration, but until plugins are configurable, it seems better to enable it for now.
