### PR TITLE
Feature/openstack network detection

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -419,11 +419,13 @@
           "floating_ip": {
             "type": "checkbox",
             "label": "Floating IP",
+            "override": true,
             "tip": "Request a floating IP address for each node"
           },
           "network_ids": {
             "label": "Network IDs",
             "type": "text",
+            "override": true,
             "tip": "Comma separated list of the UUID(s) of the network(s) for the server to attach"
           },
           "openstack_ssl_verify_peer": {
@@ -455,16 +457,6 @@
             "type": "text",
             "label": "Availability Zone",
             "tip": "Openstack Availability Zone"
-          },
-          "floating_ip": {
-            "type": "checkbox",
-            "label": "Floating IP",
-            "tip": "Request a floating IP address for each node"
-          },
-          "network_ids": {
-            "label": "Network IDs",
-            "type": "text",
-            "tip": "Comma separated list of the UUID(s) of the network(s) for the server to attach"
           },
           "user_data_resource": {
             "label": "User Data Resource Name",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -416,6 +416,16 @@
             "type": "text",
             "tip": "Name of the SSH private key resource uploaded to the server"
           },
+          "floating_ip": {
+            "type": "checkbox",
+            "label": "Floating IP",
+            "tip": "Request a floating IP address for each node"
+          },
+          "network_ids": {
+            "label": "Network IDs",
+            "type": "text",
+            "tip": "Comma separated list of the UUID(s) of the network(s) for the server to attach"
+          },
           "openstack_ssl_verify_peer": {
             "label": "Verify SSL peers",
             "type": "checkbox",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -50,7 +50,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
       }
 
       create_options[:user_data] = open(File.join(Dir.pwd, self.class.user_data_dir, @user_data_resource), &:read) if @user_data_resource
-      create_options[:nics] = @network_ids.split(',').map { |nic| nic_id = { 'net_id' => nic.strip } } if @network_ids
+      create_options[:nics] = @network_ids.split(',').map { |nic| { 'net_id' => nic.strip } } if @network_ids
 
       server = connection.servers.create(create_options)
 
@@ -201,9 +201,8 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
 
   def connection
     # Create connection
-    # rubocop:disable UselessAssignment
     @connection ||= begin
-      connection = Fog::Compute.new(
+      Fog::Compute.new(
         provider: 'OpenStack',
         openstack_auth_url: @openstack_auth_url,
         openstack_username: @api_user,
@@ -214,13 +213,12 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         }
       )
     end
-    # rubocop:enable UselessAssignment
   end
 
   def connection_network
     # Create connection to Network service
     @connection_network ||= begin
-      connection = Fog::Network.new(
+      Fog::Network.new(
         provider: 'OpenStack',
         openstack_auth_url: @openstack_auth_url,
         openstack_username: @api_user,

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -49,8 +49,8 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         key_name: @ssh_keypair
       }
 
-      create_options.merge!(user_data: open(File.join(Dir.pwd, self.class.user_data_dir, @user_data_resource)) { |f| f.read }) if @user_data_resource
-      create_options.merge!(nics: @network_ids.split(',').map { |nic| nic_id = { 'net_id' => nic.strip } }) if @network_ids
+      create_options[:user_data] = open(File.join(Dir.pwd, self.class.user_data_dir, @user_data_resource), &:read) if @user_data_resource
+      create_options[:nics] = @network_ids.split(',').map { |nic| nic_id = { 'net_id' => nic.strip } } if @network_ids
 
       server = connection.servers.create(create_options)
 
@@ -87,7 +87,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
       log.debug "Invoking server confirm for id: #{providerid}"
       server = connection.servers.get(providerid)
       # Wait until the server is ready
-      fail "Server #{server.name} is in ERROR state" if server.state == 'ERROR'
+      raise "Server #{server.name} is in ERROR state" if server.state == 'ERROR'
       log.debug "waiting for server to come up: #{providerid}"
       server.wait_for(600) { ready? }
 
@@ -95,7 +95,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
       if @floating_ip
         addresses = connection.addresses
         free_floating = addresses.find_index { |a| a.fixed_ip.nil? }
-        fail 'No available floating IP found' if free_floating.nil?
+        raise 'No available floating IP found' if free_floating.nil?
         floating_address = addresses[free_floating].ip
         server.associate_address(floating_address)
         # a bit of a hack, but server.reload takes a long time
@@ -108,7 +108,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         server.addresses.first[1][0]['addr']
       if bootstrap_ip.nil?
         log.error 'No IP address available for bootstrapping.'
-        fail 'No IP address available for bootstrapping.'
+        raise 'No IP address available for bootstrapping.'
       else
         log.debug "Bootstrap IP address #{bootstrap_ip}"
       end
@@ -177,7 +177,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
       # Delete server
       log.debug 'Invoking server delete'
       begin
-        fail ArgumentError if providerid.nil? || providerid.empty?
+        raise ArgumentError if providerid.nil? || providerid.empty?
         server = connection.servers.get(providerid)
         server.destroy
       rescue ArgumentError
@@ -240,7 +240,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
 
       all_networks = connection_network.networks
       if all_networks
-         @network_ids.split(',').each do |id|
+        @network_ids.split(',').each do |id|
           found_network = all_networks.find { |n| n.id == id }
           network_names.push(found_network.name) if found_network.name
         end
@@ -255,7 +255,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
   end
 
   def extract_ipv4_address(ip_addresses)
-    address = ip_addresses.select { |ip| ip['version'] == 4 }.first
+    address = ip_addresses.find { |ip| ip['version'] == 4 }
     address ? address['addr'] : ''
   end
 
@@ -269,10 +269,9 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
     names.push('private')
 
     names.each do |name|
-      if addresses[name]
-        addresses[name].reverse_each do |addr|
-          return addr['addr'] if addr['OS-EXT-IPS:type'] == 'fixed'
-        end
+      next unless addresses[name]
+      addresses[name].reverse_each do |addr|
+        return addr['addr'] if addr['OS-EXT-IPS:type'] == 'fixed'
       end
     end
 
@@ -286,10 +285,9 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
     names.push('private')
 
     names.each do |name|
-      if addresses[name]
-        addresses[name].reverse_each do |addr|
-          return addr['addr'] if addr['OS-EXT-IPS:type'] == 'floating'
-        end
+      next unless addresses[name]
+      addresses[name].reverse_each do |addr|
+        return addr['addr'] if addr['OS-EXT-IPS:type'] == 'floating'
       end
     end
   end


### PR DESCRIPTION
- [x] enhance public/private IP detection logic to take advantage of the case where network_ids is specified, and/or the common OS-EXT-IPS extension is installed.  Otherwise, it defaults back to the old behavior.
  - [x] lookup network names from the specified network_ids
  - [x] search networks and return first fixed ip for "private", and first "floating" ip for public
- [x] make `floating_ip` and `network_ids` admin fields so defaults can be set
- [x] style fixes
