### PR TITLE
attempt to preserve env when running sudo

### DIFF
--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -60,7 +60,7 @@ class DockerAutomator < Coopr::Plugin::Automator
       if root == false || @sshuser == 'root'
         nil
       else
-        'sudo'
+        'sudo -E'
       end
     Net::SSH.start(@ipaddress, @sshuser, @credentials) do |ssh|
       ssh_exec!(ssh, "#{sudo} #{cmd}", "Running: #{cmd}")

--- a/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -106,7 +106,7 @@ class ShellAutomator < Coopr::Plugin::Automator
     shellargs = fields['args']
 
     # do we need sudo bash?
-    sudo = 'sudo' unless sshauth['user'] == 'root'
+    sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
     write_ssh_file
     @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
@@ -159,7 +159,7 @@ class ShellAutomator < Coopr::Plugin::Automator
     ipaddress = inputmap['ipaddress']
 
     # do we need sudo bash?
-    sudo = 'sudo' unless sshauth['user'] == 'root'
+    sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
     write_ssh_file
     @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -134,7 +134,7 @@ class FogProviderAWS < Coopr::Plugin::Provider
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?
-      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
+      sudo = 'sudo -E' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/digitalocean.rb
@@ -133,7 +133,7 @@ class FogProviderDigitalOcean < Coopr::Plugin::Provider
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?
-      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
+      sudo = 'sudo -E' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -175,7 +175,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?
-      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
+      sudo = 'sudo -E' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/joyent.rb
@@ -111,7 +111,7 @@ class FogProviderJoyent < Coopr::Plugin::Provider
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?
-      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
+      sudo = 'sudo -E' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
       
       # login with pseudotty and turn off sudo requiretty option

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -127,7 +127,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?
-      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
+      sudo = 'sudo -E' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/rackspace.rb
@@ -114,7 +114,7 @@ class FogProviderRackspace < Coopr::Plugin::Provider
         'rsa' => ssh_keyscan(bootstrap_ip)
       }
       # do we need sudo bash?
-      sudo = 'sudo' unless @task['config']['ssh-auth']['user'] == 'root'
+      sudo = 'sudo -E' unless @task['config']['ssh-auth']['user'] == 'root'
       set_credentials(@task['config']['ssh-auth'])
 
       # login with pseudotty and turn off sudo requiretty option


### PR DESCRIPTION
Attempts to preserve environment variables when running commands. This is particularly useful if commands are dependent on http_proxy variables or similar.

Same as https://github.com/caskdata/coopr-provisioner/pull/127 but for all additional plugins, per PR feedback.
