### PR TITLE
COOPR-811 Replace safe_format_and_mount with mkfs/mount

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -214,7 +214,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
             cmd = "#{sudo} readlink /dev/disk/by-id/#{google_disk_id}"
             device_rel_path = ssh_exec!(ssh, cmd, "Querying disk #{google_disk_id}").first.chomp
             device = File.join('/dev', File.basename(device_rel_path))
-            cmd = "#{sudo} mkdir #{mount_point} && #{sudo} /usr/share/google/safe_format_and_mount -m 'mkfs.ext4 -F' #{device} #{mount_point}"
+            cmd = "#{sudo} mkdir #{mount_point} && #{sudo} /sbin/mkfs.ext4 #{device} && #{sudo} mount -o #{device} #{mount_point}"
             ssh_exec!(ssh, cmd, "Mounting device #{device} on #{mount_point}")
             # update /etc/fstab
             cmd = "echo '#{device} #{mount_point} ext4 defaults,auto,noatime 0 2' | #{sudo} tee -a /etc/fstab"


### PR DESCRIPTION
Newer GCE images don't have the `safe_format_and_mount` script. Since we normally would unconditionally format, I am doing the same, here. I filed [COOPR-812](https://issues.cask.co/browse/COOPR-812) to fix that in all the plugins.
