### PR TITLE
Fix Travis builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,11 @@ gem 'rake'
 
 group :dependencies do
   # These gems are used by the provisioner
-  gem 'json'
+  if RUBY_VERSION.to_f < 2.0
+    gem 'json', '< 2.0'
+  else
+    gem 'json'
+  end
   gem 'logger'
   gem 'mime-types', '< 3.0'
   gem 'net-scp'
@@ -31,7 +35,6 @@ group :dependencies do
 end
 
 group :test do
-  gem 'rake'
   gem 'rack-test', '~> 0.6'
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '~> 0.24'

--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -140,7 +140,7 @@ module Coopr
       end
 
       def validate_server_connectivity
-        uri = %W( #{@options[:uri]} status ).join('/')
+        uri = %W(#{@options[:uri]} status).join('/')
         resp = Coopr::RestHelper.get(uri, @headers)
         unless resp.code == 200
           raise "non-ok response code #{resp.code} from server at: #{uri}"
@@ -150,7 +150,7 @@ module Coopr
       # query server api for given plugin_type and ensure the resource can be uploaded
       def validate_server_target
         validate_server_connectivity
-        uri = %W( #{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]}).join('/')
+        uri = %W(#{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]}).join('/')
         resp = Coopr::RestHelper.get(uri, @headers)
         if resp.code == 200
           begin
@@ -231,7 +231,7 @@ module Coopr
       end
 
       def upload_resource(payload)
-        uri = %W( #{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]} #{@options[:resource_type]} #{@options[:resource_name]}).join('/')
+        uri = %W(#{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]} #{@options[:resource_type]} #{@options[:resource_name]}).join('/')
         resp = Coopr::RestHelper.post(uri, payload, @headers)
         if resp.code == 200
           resp_obj = JSON.parse(resp.to_str)
@@ -244,7 +244,7 @@ module Coopr
 
       def stage
         version = @upload_results['version']
-        uri = %W( #{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]} #{@options[:resource_type]} #{@options[:resource_name]} versions #{version} stage).join('/')
+        uri = %W(#{@options[:uri]} v2/plugins #{@options[:plugin_type]} #{@options[:plugin_name]} #{@options[:resource_type]} #{@options[:resource_name]} versions #{version} stage).join('/')
         resp = Coopr::RestHelper.post(uri, nil, @headers)
         if resp.code == 200
           puts "stage successful for #{uri}" unless options[:quiet]
@@ -255,7 +255,7 @@ module Coopr
 
       # syncing will act on all staged resources, not just the resource being staged
       def sync
-        uri = %W( #{@options[:uri]} v2/plugins/sync).join('/')
+        uri = %W(#{@options[:uri]} v2/plugins/sync).join('/')
         resp = Coopr::RestHelper.post(uri, nil, @headers)
         if resp.code == 200
           puts 'sync successful' unless options[:quiet]

--- a/lib/provisioner/resourcemanager.rb
+++ b/lib/provisioner/resourcemanager.rb
@@ -37,8 +37,8 @@ module Coopr
       @resourcespec = resourcespec
       @config = config
       @tenant = tenant
-      @datadir = %W( #{config.get(PROVISIONER_DATA_DIR)} #{tenant} ).join('/')
-      @workdir = %W( #{config.get(PROVISIONER_WORK_DIR)} #{tenant} ).join('/')
+      @datadir = %W(#{config.get(PROVISIONER_DATA_DIR)} #{tenant}).join('/')
+      @workdir = %W(#{config.get(PROVISIONER_WORK_DIR)} #{tenant}).join('/')
       @active = {}
     end
 
@@ -91,7 +91,7 @@ module Coopr
       fetch_resource(resource, version) do |download_file|
         # move downloaded file to its place in data dir
         # ex: data/tenant1/automatortype/chef-solo/roles/cluster.json/1/cluster.json
-        data_file = %W( #{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
+        data_file = %W(#{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
         log.debug "storing fetched file #{download_file} into data dir: #{data_file}"
         # set file permissions if specified
         if @resourcespec.resource_permissions.key?(resource) && !@resourcespec.resource_permissions[resource].nil?
@@ -107,7 +107,7 @@ module Coopr
     # sync a resource to the local data directory as an exploded archive
     def sync_archive_resource(resource, version)
       fetch_resource(resource, version) do |archive|
-        dest_dir = %W( #{@datadir} #{resource} #{version} ).join('/')
+        dest_dir = %W(#{@datadir} #{resource} #{version}).join('/')
         log.debug "exploding fetched archive #{archive} into data dir: #{dest_dir}"
         # process the tar.gz
         Gem::Package::TarReader.new(Zlib::GzipReader.open(archive)) do |targz|
@@ -145,7 +145,7 @@ module Coopr
 
     # fetches a resource from the server to a tmp directory, yields the file location to a block
     def fetch_resource(resource, version)
-      uri = %W( #{@config.get(PROVISIONER_SERVER_URI)} v2/tenants/#{@tenant} #{resource} versions #{version} ).join('/')
+      uri = %W(#{@config.get(PROVISIONER_SERVER_URI)} v2/tenants/#{@tenant} #{resource} versions #{version}).join('/')
       log.debug "fetching resource at #{uri} for tenant #{@tenant}"
       begin
         response = Coopr::RestHelper.get(uri, 'Coopr-UserID' => 'admin', 'Coopr-TenantID' => @tenant)
@@ -161,7 +161,7 @@ module Coopr
 
       # write the response to tmp file
       tmpdir = Dir.mktmpdir
-      tmpfile = %W( #{tmpdir} #{resource.split('/')[-1]} ).join('/')
+      tmpfile = %W(#{tmpdir} #{resource.split('/')[-1]}).join('/')
       File.open(tmpfile, 'w') do |f|
         f.write response.body
       end
@@ -173,7 +173,7 @@ module Coopr
     # deletes a resource from the local data directory
     def delete_resource(resource, version)
       log.debug "deleting resource #{resource} #{version}"
-      data_file = %W( #{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
+      data_file = %W(#{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
       # delete either the file or directory from data dir
       File.delete data_file if File.file? data_file
       FileUtils.rm_rf data_file if File.directory? data_file
@@ -185,8 +185,8 @@ module Coopr
         log.error "attempt to activate resource #{resource} version #{version} but it is not synced from server"
         return
       end
-      data_file = %W( #{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
-      work_link = %W( #{@workdir} #{resource} ).join('/')
+      data_file = %W(#{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
+      work_link = %W(#{@workdir} #{resource}).join('/')
       deactivate_resource(resource) if File.symlink?(work_link)
       FileUtils.mkdir_p(File.dirname(work_link))
       File.symlink data_file, work_link
@@ -195,7 +195,7 @@ module Coopr
 
     # deactivate a resource by removing the work dir symlink
     def deactivate_resource(resource)
-      work_link = %W( #{@workdir} #{resource} ).join('/')
+      work_link = %W(#{@workdir} #{resource}).join('/')
       log.debug "deactivating: #{work_link}"
       File.delete(work_link) if File.symlink?(work_link)
       log.debug "deactivated resource #{resource}"
@@ -203,7 +203,7 @@ module Coopr
 
     # get active version for a given resource
     def active_version(resource)
-      work_link = %W( #{@workdir} #{resource} ).join('/')
+      work_link = %W(#{@workdir} #{resource}).join('/')
       return nil unless File.symlink? work_link
       target = File.readlink(work_link)
       target.split('/')[-2]
@@ -211,7 +211,7 @@ module Coopr
 
     # determine if a versioned resource exists in the data dir
     def synced?(resource, version)
-      data = %W( #{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
+      data = %W(#{@datadir} #{resource} #{version} #{resource.split('/')[-1]}).join('/')
 
       # if data is a directory, its an archive resource and its synced
       return true if File.directory?(data)

--- a/lib/provisioner/resourcespec.rb
+++ b/lib/provisioner/resourcespec.rb
@@ -55,7 +55,7 @@ module Coopr
               h_resource['active'].each do |nv|
                 name = nv['name']
                 version = nv['version']
-                resource_name = %W( #{type} #{id} #{resource_type} #{name}).join('/')
+                resource_name = %W(#{type} #{id} #{resource_type} #{name}).join('/')
                 @resources[resource_name] = version
                 @resource_formats[resource_name] = format
                 @resource_permissions[resource_name] = permissions unless permissions.nil?


### PR DESCRIPTION
This restricts the `json` Gem on Ruby < 2.0 (Coopr provisioner ships 1.9.3) and updates some white space to make `rubocop` happy.
