### PR TITLE
Use the same options as Google, otherwise mkfs.ext4 is interactive

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -214,7 +214,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
             cmd = "#{sudo} readlink /dev/disk/by-id/#{google_disk_id}"
             device_rel_path = ssh_exec!(ssh, cmd, "Querying disk #{google_disk_id}").first.chomp
             device = File.join('/dev', File.basename(device_rel_path))
-            cmd = "#{sudo} mkdir #{mount_point} && #{sudo} /sbin/mkfs.ext4 #{device} && #{sudo} mount -o #{device} #{mount_point}"
+            cmd = "#{sudo} mkdir #{mount_point} && #{sudo} /sbin/mkfs.ext4 -E lazy_itable_init=0 -F #{device} && #{sudo} mount -o discard,defaults #{device} #{mount_point}"
             ssh_exec!(ssh, cmd, "Mounting device #{device} on #{mount_point}")
             # update /etc/fstab
             cmd = "echo '#{device} #{mount_point} ext4 defaults,auto,noatime 0 2' | #{sudo} tee -a /etc/fstab"


### PR DESCRIPTION
These are copied from `/usr/share/google/safe_format_and_mount` on an older GCE instance.

```
MOUNT_OPTIONS="discard,defaults"
MKFS="mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -F"
```

I did _not_ include `lazy_journal_init=0` due to the following error.

```
# /sbin/mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -F /dev/sdb
mke2fs 1.41.12 (17-May-2010)

Bad option(s) specified: lazy_journal_init

Extended options are separated by commas, and may take an argument which
    is set off by an equals ('=') sign.

Valid extended options are:
    stride=<RAID per-disk data chunk in blocks>
    stripe-width=<RAID stride * data disks in blocks>
    resize=<resize maximum size in blocks>
    lazy_itable_init=<0 to disable, 1 to enable>
    test_fs
    discard
    nodiscard
```
