### PR TITLE
Ensure override['build-essential']['compile_time'] = true

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/attributes/dnsimple.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/attributes/dnsimple.rb
@@ -3,3 +3,5 @@ default['dnsimple']['fog_version'] = '1.21.0'
 # Our configuration
 default['coopr_dns']['dnsimple']['databag_name'] = 'creds'
 default['coopr_dns']['dnsimple']['databag_item'] = 'dnsimple'
+# Ensure we run build-essential at compile-time
+override['build-essential']['compile_time'] = true

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Installs/Configures DNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 depends 'dnsimple'
 depends 'build-essential'


### PR DESCRIPTION
The `dnsimple` cookbook has the deprecated property. Make sure we set the current property.
