### PR TITLE
Restrict rubocop and update to make newer versions happy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,11 @@ end
 group :test do
   gem 'rack-test', '~> 0.6'
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '~> 0.24'
+  if RUBY_VERSION.to_f < 2.0
+    gem 'rubocop', '< 0.42'
+  else
+    gem 'rubocop', '~> 0.24'
+  end
   gem 'simplecov', '~> 0.7.1', require: false
 end
 

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -99,7 +99,7 @@ module Coopr
         log.debug "stderr: #{stderr_data}"
         log.debug "stdout: #{stdout_data}"
 
-        raise CommandExecutionError.new(command, stdout_data, stderr_data, exit_code, exit_signal), message unless exit_code == 0
+        raise CommandExecutionError.new(command, stdout_data, stderr_data, exit_code, exit_signal), message unless exit_code.zero?
 
         [stdout_data, stderr_data, exit_code, exit_signal]
       end

--- a/lib/provisioner/provisioner.rb
+++ b/lib/provisioner/provisioner.rb
@@ -213,7 +213,7 @@ module Coopr
         log.info 'starting resource thread'
         loop do
           @tenantmanagers.each do |_id, tmgr|
-            next unless tmgr.resource_sync_needed? && tmgr.num_workers == 0
+            next unless tmgr.resource_sync_needed? && tmgr.num_workers.zero?
             while tmgr.resource_sync_needed?
               log.debug "resource thread invoking sync for tenant #{tmgr.id}"
               tmgr.sync
@@ -308,7 +308,7 @@ module Coopr
     # api method to delete tenant for given id
     def delete_tenant(id)
       # if no workers currently running, just delete
-      if @tenantmanagers[id].num_workers == 0
+      if @tenantmanagers[id].num_workers.zero?
         @tenantmanagers.delete(id)
       else
         # instruct tenant to send kill signal to its workers
@@ -324,7 +324,7 @@ module Coopr
         # update worker counts
         v.verify_workers
         # has this tenant been deleted?
-        if @terminating_tenants.include?(k) && v.num_workers == 0
+        if @terminating_tenants.include?(k) && v.num_workers.zero?
           @tenantmanagers.delete(k)
           @terminating_tenants.delete(k)
         end

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -154,7 +154,7 @@ module Coopr
       FileUtils.mkdir_p(cwd)
       Dir.chdir(cwd) do
         result = object.runTask
-        log.info "#{clusterId} on #{hostname} could not be deleted: #{result['message']}" if taskName == 'delete' && result['status'] != 0
+        log.info "#{clusterId} on #{hostname} could not be deleted: #{result['message']}" if taskName == 'delete' && result['status'].nonzero?
         result
       end
     end


### PR DESCRIPTION
Newer rubocop doesn't like comparing against the integer 0... use `.zero?` and `.nonzero?` instead.
