### PR TITLE
Support GCE Persistent SSD for root/data disks

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -248,12 +248,34 @@
             "override": true,
             "tip": "Size of the persistent data disk to be created and mounted. Multiple disks can be specified as a comma-separated list"
           },
+          "google_data_disk_type": {
+            "label": "Data disk(s) type",
+            "type": "select",
+            "options": [
+              "standard",
+              "ssd"
+            ],
+            "default": "standard",
+            "override": true,
+            "tip": "Disk type"
+          },
           "google_root_disk_size_gb": {
             "label": "Root disk size in GB",
             "type": "text",
             "default": 10,
             "override": true,
             "tip": "Size of the root disk to be created. Image must support resizing, or you must resize yourself"
+          },
+          "google_root_disk_type": {
+            "label": "Root disk type",
+            "type": "select",
+            "options": [
+              "standard",
+              "ssd"
+            ],
+            "default": "standard",
+            "override": true,
+            "tip": "Disk type"
           },
           "zone_name": {
             "label": "Zone",


### PR DESCRIPTION
This allows using Persistent SSD disks for either `root` or `data` disks and is supported in the current version of `fog` used in the plugin.
