### PR TITLE
Put 6.7, 6.8, and upcoming 6.9 in version matrix

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/docker/attributes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/docker/attributes/default.rb
@@ -15,7 +15,7 @@ default['docker']['init_type'] = value_for_platform(
     'default' => 'sysv'
   },
   %w(redhat centos) => {
-    %w(6.0 6.1 6.2 6.3 6.4 6.5 6.6) => 'sysv',
+    %w(6.0 6.1 6.2 6.3 6.4 6.5 6.6 6.7 6.8 6.9) => 'sysv',
     'default' => 'systemd'
   },
   %w(fedora) => {
@@ -86,7 +86,7 @@ default['docker']['package']['name'] = value_for_platform(
     'default' => 'docker'
   },
   %w(centos redhat) => {
-    %w(6.0 6.1 6.2 6.3 6.4 6.5 6.6) => 'docker-io',
+    %w(6.0 6.1 6.2 6.3 6.4 6.5 6.6 6.7 6.8 6.9) => 'docker-io',
     'default' => 'docker'
   },
   'fedora' => {


### PR DESCRIPTION
This version of the Docker cookbook was released before these versions of RHEL/CentOS were released. Adding them to the version matrix, so we choose the correct init method (and thereby recipe)
