### PR TITLE
Setup codeclimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,17 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/
+- lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/


### PR DESCRIPTION
This is essentially the default configuration, restricted to just Ruby and tests. Also, I have excluded the resources from `chef_solo_automator` as most of them are from upstream.
