### PR TITLE
Move write_ssh_file to Coopr::Plugin::Utils

### DIFF
--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 #
-# Copyright © 2012-2015 Cask Data, Inc.
+# Copyright © 2012-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ module Coopr
         identityfile = ::File.join(path, task['taskId'])
         log.debug "Writing out SSH private key to #{identityfile}" unless ssh_keyfile.nil?
         decode_string_to_file(ssh_keyfile, identityfile) unless ssh_keyfile.nil?
+        identityfile
       end
 
       # Gets a host's SSH host key

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -57,13 +57,14 @@ module Coopr
         ::File.open(outfile, 'wb', mode) { |f| f.write(::Base64.decode64(string)) }
       end
 
-      # Writes out an SSH file, given a path and task JSON, returns fully-qualified path to file
+      # Writes out an SSH file, given a path and task JSON, returns fully-qualified path to file, or nil
       def write_ssh_file(path, task)
-        ssh_keyfile = task['config']['provider']['provisioner']['ssh_keyfile'] || nil
-        identityfile = ::File.join(path, task['taskId'])
-        log.debug "Writing out SSH private key to #{identityfile}" unless ssh_keyfile.nil?
-        decode_string_to_file(ssh_keyfile, identityfile) unless ssh_keyfile.nil?
-        identityfile
+        if task['config']['provider']['provisioner'].key?('ssh_keyfile')
+          identityfile = ::File.join(path, task['taskId'])
+          log.debug "Writing out SSH private key to #{identityfile}"
+          decode_string_to_file(ssh_keyfile, identityfile)
+          identityfile
+        end
       end
 
       # Gets a host's SSH host key

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -59,13 +59,12 @@ module Coopr
 
       # Writes out an SSH file, given a path and task JSON, returns fully-qualified path to file, or nil
       def write_ssh_file(path, task)
-        if task['config']['provider']['provisioner'].key?('ssh_keyfile')
-          identityfile = ::File.join(path, task['taskId'])
-          ssh_keyfile = task['config']['provider']['provisioner']['ssh_keyfile']
-          log.debug "Writing out SSH private key to #{identityfile}"
-          decode_string_to_file(ssh_keyfile, identityfile)
-          identityfile
-        end
+        return nil unless task['config']['provider']['provisioner'].key?('ssh_keyfile')
+        ssh_keyfile = task['config']['provider']['provisioner']['ssh_keyfile']
+        identityfile = ::File.join(path, task['taskId'])
+        log.debug "Writing out SSH private key to #{identityfile}"
+        decode_string_to_file(ssh_keyfile, identityfile)
+        identityfile
       end
 
       # Gets a host's SSH host key

--- a/lib/provisioner/plugin/utils.rb
+++ b/lib/provisioner/plugin/utils.rb
@@ -61,6 +61,7 @@ module Coopr
       def write_ssh_file(path, task)
         if task['config']['provider']['provisioner'].key?('ssh_keyfile')
           identityfile = ::File.join(path, task['taskId'])
+          ssh_keyfile = task['config']['provider']['provisioner']['ssh_keyfile']
           log.debug "Writing out SSH private key to #{identityfile}"
           decode_string_to_file(ssh_keyfile, identityfile)
           identityfile

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -131,8 +131,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     set_credentials(sshauth)
 
     @@chef_primitives.each do |chef_primitive|
@@ -209,7 +208,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     log.debug "ChefSoloAutomator bootstrap completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def runchef(inputmap)
@@ -232,8 +231,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     set_credentials(sshauth)
 
     begin
@@ -270,7 +268,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     log.debug "Chef-solo run completed successfully for task #{@task['taskId']}: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def install_chef(inputmap)
@@ -280,8 +278,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     set_credentials(sshauth)
 
     begin
@@ -322,6 +319,8 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     rescue
       raise 'Failed to install Chef'
     end
+  ensure
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def install(inputmap)

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -60,15 +60,6 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # rubocop:enable GuardClause
   end
 
-  def write_ssh_file
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    unless @ssh_keyfile.nil?
-      @task['config']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @task['taskId'])
-      log.debug "Writing out @ssh_keyfile to #{@task['config']['ssh-auth']['identityfile']}"
-      decode_string_to_file(@ssh_keyfile, @task['config']['ssh-auth']['identityfile'])
-    end
-  end
-
   def set_credentials(sshauth)
     @credentials = {}
     @credentials[:paranoid] = false
@@ -79,11 +70,6 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
         @credentials[:password] = v
       end
     end
-  end
-
-  def decode_string_to_file(string, outfile, mode = 0600)
-    FileUtils.mkdir_p(File.dirname(outfile))
-    File.open(outfile, 'wb', mode) { |f| f.write(Base64.decode64(string)) }
   end
 
   # generate the chef run json_attributes from the task metadata
@@ -145,8 +131,8 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    write_ssh_file
-    @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
+    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
+    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
     set_credentials(sshauth)
 
     @@chef_primitives.each do |chef_primitive|
@@ -246,8 +232,8 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    write_ssh_file
-    @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
+    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
+    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
     set_credentials(sshauth)
 
     begin
@@ -294,8 +280,8 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    write_ssh_file
-    @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
+    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
+    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
     set_credentials(sshauth)
 
     begin

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.rb
@@ -161,8 +161,7 @@ class DockerAutomator < Coopr::Plugin::Automator
   def bootstrap(inputmap)
     log.debug "DockerAutomator performing bootstrap task #{@task['taskId']}"
     parse_inputmap(inputmap)
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     log.debug "Attempting ssh into ip: #{@ipaddress}, user: #{@sshuser}"
     begin
       Net::SSH.start(@ipaddress, @sshuser, @credentials) do |ssh|
@@ -175,14 +174,13 @@ class DockerAutomator < Coopr::Plugin::Automator
     log.debug "DockerAutomator bootstrap completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def install(inputmap)
     log.debug "DockerAutomator performing install task #{@task['taskId']}"
     parse_inputmap(inputmap)
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     log.debug "Attempting ssh into ip: #{@ipaddress}, user: #{@sshuser}"
     setup_host_volumes(@vols)
     pull_image(@image_name) if search_image(@image_name)
@@ -190,7 +188,7 @@ class DockerAutomator < Coopr::Plugin::Automator
     log.debug "DockerAutomator install completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def configure(*)
@@ -206,8 +204,7 @@ class DockerAutomator < Coopr::Plugin::Automator
   def start(inputmap)
     log.debug "DockerAutomator performing start task #{@task['taskId']}"
     parse_inputmap(inputmap)
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     log.debug "Attempting ssh into ip: #{@ipaddress}, user: #{@sshuser}"
     @result['result'][@image_name]['id'] = run_container(@image_name, @command)[0].chomp
     @result['result']['ports'] = @ports
@@ -215,14 +212,13 @@ class DockerAutomator < Coopr::Plugin::Automator
     log.debug "DockerAutomator start completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def stop(inputmap)
     log.debug "DockerAutomator performing stop task #{@task['taskId']}"
     parse_inputmap(inputmap)
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     log.debug "Attempting ssh into ip: #{@ipaddress}, user: #{@sshuser}"
     stop_container(@task['config'][@image_name]['id'])
     @result['result']['ports'] = nil
@@ -230,14 +226,13 @@ class DockerAutomator < Coopr::Plugin::Automator
     log.debug "DockerAutomator stop completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def remove(inputmap)
     log.debug "DockerAutomator performing remove task #{@task['taskId']}"
     parse_inputmap(inputmap)
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     log.debug "Attempting ssh into ip: #{@ipaddress}, user: #{@sshuser}"
     remove_container(@task['config'][@image_name]['id'])
     @task['config'][@image_name] = {}
@@ -245,6 +240,6 @@ class DockerAutomator < Coopr::Plugin::Automator
     log.debug "DockerAutomator remove completed successfully: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 end

--- a/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -92,8 +92,7 @@ class ShellAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     set_credentials(sshauth)
 
     jsondata = JSON.generate(task)
@@ -135,7 +134,7 @@ class ShellAutomator < Coopr::Plugin::Automator
     log.debug "Result of shell command: #{@result}"
     @result
   ensure
-    File.delete(@ssh_file) if @ssh_file && File.exist?(@ssh_file)
+    File.delete(ssh_file) if ssh_file && File.exist?(ssh_file)
   end
 
   def bootstrap(inputmap)
@@ -145,8 +144,7 @@ class ShellAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
+    ssh_file = write_ssh_file(File.join(Dir.pwd, self.class.ssh_key_dir), @task)
     set_credentials(sshauth)
 
     # generate the local tarballs for resources and for our own wrapper libs

--- a/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/shell_automator/shell_automator.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 #
-# Copyright © 2012-2014 Cask Data, Inc.
+# Copyright © 2012-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 #
 
 require 'net/scp'
-require 'base64'
-require 'fileutils'
 require 'rubygems/package'
 require 'zlib'
 
@@ -70,15 +68,6 @@ class ShellAutomator < Coopr::Plugin::Automator
     log.debug "Generation complete: #{file}"
   end
 
-  def write_ssh_file
-    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
-    unless @ssh_keyfile.nil?
-      @task['config']['ssh-auth']['identityfile'] = File.join(Dir.pwd, self.class.ssh_key_dir, @task['taskId'])
-      log.debug "Writing out @ssh_keyfile to #{@task['config']['ssh-auth']['identityfile']}"
-      decode_string_to_file(@ssh_keyfile, @task['config']['ssh-auth']['identityfile'])
-    end
-  end
-
   def set_credentials(sshauth)
     @credentials = Hash.new
     @credentials[:paranoid] = false
@@ -89,11 +78,6 @@ class ShellAutomator < Coopr::Plugin::Automator
         @credentials[:password] = v
       end
     end
-  end
-
-  def decode_string_to_file(string, outfile, mode = 0600)
-    FileUtils.mkdir_p(File.dirname(outfile))
-    File.open(outfile, 'wb', mode) { |f| f.write(Base64.decode64(string)) }
   end
 
   def runshell(inputmap)
@@ -108,8 +92,8 @@ class ShellAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    write_ssh_file
-    @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
+    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
+    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
     set_credentials(sshauth)
 
     jsondata = JSON.generate(task)
@@ -161,8 +145,8 @@ class ShellAutomator < Coopr::Plugin::Automator
     # do we need sudo bash?
     sudo = 'sudo -E' unless sshauth['user'] == 'root'
 
-    write_ssh_file
-    @ssh_file = @task['config']['ssh-auth']['identityfile'] unless @ssh_keyfile.nil?
+    @ssh_keyfile = @task['config']['provider']['provisioner']['ssh_keyfile']
+    @ssh_file = write_ssh_file(::File.join(Dir.pwd, self.class.ssh_key_dir), @task) unless @ssh_keyfile.nil?
     set_credentials(sshauth)
 
     # generate the local tarballs for resources and for our own wrapper libs


### PR DESCRIPTION
This makes this method shared among all of the plugins, versus being duplicated in each automator plugin.
