### PR TITLE
Feature/780 ubuntu 14

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -315,8 +315,13 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
           return
         rescue CommandExecutionError
           begin
-            ssh_exec!(ssh, "which apt-get && DEBIAN_FRONTEND=noninteractive #{sudo} apt-get -q -y install chef", 'Attempting Chef install via apt-get')
-            return
+            candidate_version = ssh_exec!(ssh, "#{sudo} apt-cache policy chef | grep Candidate | awk '{ print $2}'", 'Retrieving candidate Chef version').first.chomp
+            log.debug "Found chef version #{candidate_version} available for install via package repositories"
+            # Bundled cookbooks require Chef 12 or later
+            if candidate_version.to_i >= 12
+              ssh_exec!(ssh, "which apt-get && DEBIAN_FRONTEND=noninteractive #{sudo} apt-get -q -y install chef", 'Attempting Chef install via apt-get')
+              return
+            end
           rescue
             log.debug 'No Chef packages found for installation'
           end

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -317,8 +317,8 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
           begin
             candidate_version = ssh_exec!(ssh, "#{sudo} apt-cache policy chef | grep Candidate | awk '{ print $2}'", 'Retrieving candidate Chef version').first.chomp
             log.debug "Found chef version #{candidate_version} available for install via package repositories"
-            # Bundled cookbooks require Chef 12 or later
-            if candidate_version.to_i >= 12
+            # Bundled cookbooks require Chef 12.1 or later
+            if candidate_version.to_f >= 12.1
               ssh_exec!(ssh, "which apt-get && DEBIAN_FRONTEND=noninteractive #{sudo} apt-get -q -y install chef", 'Attempting Chef install via apt-get')
               return
             end

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -315,7 +315,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
           return
         rescue CommandExecutionError
           begin
-            ssh_exec!(ssh, "which apt-get && #{sudo} apt-get -q -y install chef", 'Attempting Chef install via apt-get')
+            ssh_exec!(ssh, "which apt-get && DEBIAN_FRONTEND=noninteractive #{sudo} apt-get -q -y install chef", 'Attempting Chef install via apt-get')
             return
           rescue
             log.debug 'No Chef packages found for installation'


### PR DESCRIPTION
fixes [COOPR-780](https://issues.cask.co/browse/COOPR-780)
- [x] avoid the Chef package's apt postinstall interactive GUI prompt by setting `DEBIAN_FRONTEND`
- [x] only install if the candidate Chef version is greater than 12, since that's what our bundled cookbooks now require.
