### PR TITLE
Restrict json and google-api-client gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,7 @@ gem 'rake'
 
 group :dependencies do
   # These gems are used by the provisioner
-  if RUBY_VERSION.to_f < 2.0
-    gem 'json', '< 2.0'
-  else
-    gem 'json'
-  end
+  gem 'json', '~> 1.7.7'
   gem 'logger'
   gem 'mime-types', '< 3.0'
   gem 'net-scp'

--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require 'json'
 require 'optparse'
 require 'rest_client'

--- a/lib/provisioner/api.rb
+++ b/lib/provisioner/api.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require 'thin'
 require 'sinatra/base'
 require 'json'

--- a/lib/provisioner/provisioner.rb
+++ b/lib/provisioner/provisioner.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require 'thin'
 require 'sinatra/base'
 require 'json'

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require 'json'
 require 'optparse'
 require 'rest_client'

--- a/lib/provisioner/worker/pluginmanager.rb
+++ b/lib/provisioner/worker/pluginmanager.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 require 'json'
 require 'rest_client'
 require_relative '../plugin/automator'

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider.rb
@@ -24,6 +24,7 @@ require_relative 'fog_provider/openstack'
 require_relative 'fog_provider/rackspace'
 
 gem 'fog', '~> 1.36.0'
+gem 'google-api-client', '~> 0.8.0'
 
 require 'fog'
 require 'ipaddr'

--- a/spec/automator_spec.rb
+++ b/spec/automator_spec.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require_relative 'spec_helper'
 require 'json'
 

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require_relative 'spec_helper'
 require 'json'
 

--- a/spec/tenant_worker_request.rb
+++ b/spec/tenant_worker_request.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+gem 'json', '~> 1.7.7' # activesupport
+
 require 'json'
 require_relative '../lib/provisioner/rest-helper'
 


### PR DESCRIPTION
This restricts the run-time loading of these gems. Continuation of #160 for cases where a newer Gem is already present on the host machine.
