### PR TITLE
add noninteractive flag to apt-get upgrade

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -41,6 +41,7 @@ case pf
 when 'debian'
   execute 'update-apt-packages' do
     command 'apt-get update && apt-get upgrade -y && apt-get install -y unattended-upgrades'
+    environment 'DEBIAN_FRONTEND' => 'noninteractive'
     not_if { node['coopr_packages']['skip_updates'].to_s == 'true' }
   end
 when 'rhel'


### PR DESCRIPTION
prevent interactive prompt failures by setting `DEBIAN_FRONTEND=noninteractive` during `apt-get upgrade`
