### PR TITLE
Restrict fog-profitbricks Rubygem

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -21,6 +21,7 @@
 source 'https://rubygems.org'
 
 gem 'fog', '~> 1.36.0'
+gem 'fog-profitbricks', '< 2.0' # requires a newer fog 1.42+
 gem 'net-ssh', '~> 2.6'
 
 gem 'google-api-client', '~> 0.8.6'


### PR DESCRIPTION
This version breaks the `fog` version we've installed and requires a newer `fog` so restrict it to the older version which doesn't break fog initialization.

Tested this on a distributed (omnibus) build using develop.
