### PR TITLE
Restrict addressable Gem for Ruby 1.9 support

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -25,3 +25,4 @@ gem 'fog-profitbricks', '< 2.0' # requires a newer fog 1.42+
 gem 'net-ssh', '~> 2.6'
 
 gem 'google-api-client', '~> 0.8.6'
+gem 'addressable', '< 2.5' # dependency of google-api-client, 2.5 requires Ruby 2.0+


### PR DESCRIPTION
New day, new gems... This restricts the version of `addressable` (dependency of `google-api-client`) to one that works on Ruby 1.9, as newer versions require Ruby 2.0+