### PR TITLE
check if attrs defined before using

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Removes a defined set of packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.2'
+version '0.0.3'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -29,9 +29,11 @@ end
 # Install platform-specific packages
 pf = node['platform_family']
 %w(remove install upgrade).each do |act|
-  node['coopr_packages'][pf][act].each do |cb|
-    package cb do
-      action act.to_sym
+  if node['coopr_packages'].key?(pf) && node['coopr_packages'][pf].key?(act)
+    node['coopr_packages'][pf][act].each do |cb|
+      package cb do
+        action act.to_sym
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] prevents a nilPointer in coopr_packages when using an OS without default attributes assigned