### PR TITLE
COOPR-819 Support custom repositories for Docker images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'rake'
 
 group :dependencies do
   # These gems are used by the provisioner
+  gem 'deep_merge', '~> 1.0', require: 'deep_merge/rails_compat'
   gem 'json', '~> 1.7.7'
   gem 'logger'
   gem 'mime-types', '< 3.0'
@@ -27,17 +28,20 @@ group :dependencies do
   gem 'rest_client', '~> 1.7'
   gem 'sinatra', '~> 1.4'
   gem 'thin', '~> 1.6'
-  gem 'deep_merge', '~> 1.0', require: 'deep_merge/rails_compat'
 end
 
 group :test do
   gem 'rack-test', '~> 0.6'
   gem 'rspec', '~> 3.0'
+  # rubocop: disable Lint/UnneededDisable
+  # rubocop: disable Bundler/DuplicatedGem
   if RUBY_VERSION.to_f < 2.0
     gem 'rubocop', '< 0.42'
   else
     gem 'rubocop', '~> 0.24'
   end
+  # rubocop: enable Bundler/DuplicatedGem
+  # rubocop: enable Lint/UnneededDisable
   gem 'simplecov', '~> 0.7.1', require: false
 end
 

--- a/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
+++ b/lib/provisioner/worker/plugins/automators/docker_automator/docker_automator.json
@@ -12,7 +12,7 @@
             "label": "Image Name",
             "override": false,
             "type": "text",
-            "tip": "Image name in NAME[:TAG] format"
+            "tip": "Image name in [REPOSITORY/]NAME[:TAG] format"
           },
           "environment_variables": {
             "label": "Environment variables",


### PR DESCRIPTION
Since URLs must include a `.` and Docker image names cannot contain a `.`, I am using that as a way to skip the search requirement. This will not work if the repository doesn't include at least one dot, so I am also checking if the first element in the image name is a username on Docker Hub.

Valid:
- `image`
- `username/image`
- `repository.host/image`
- `repository.host/username/image`

There's no easy way to tell if a short hostname is a username or a repository name without doing a search.

Fixes COOPR-819