### PR TITLE
return nil if floating ip not found

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/openstack.rb
@@ -295,6 +295,7 @@ class FogProviderOpenstack < Coopr::Plugin::Provider
         return addr['addr'] if addr['OS-EXT-IPS:type'] == 'floating'
       end
     end
+    nil
   end
 
   def primary_public_ip_address(addresses)


### PR DESCRIPTION
explicitly return ``nil`` when there is no floating ip.  otherwise, it returns the list of networks and fails.