### PR TITLE
add attributes for package manager options on coopr_packages installs…

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/attributes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/attributes/default.rb
@@ -27,4 +27,8 @@ default['coopr_packages']['rhel']['install'] = []
 default['coopr_packages']['rhel']['upgrade'] = []
 default['coopr_packages']['rhel']['remove'] = ['yum-cron']
 
+# options passed to the package resources, as well as the initial package upgrade
+default['coopr_packages']['debian']['options'] = '-y -o Dpkg::Options::="--force-confnew"'
+default['coopr_packages']['rhel']['options'] = '-y'
+
 default['coopr_packages']['skip_updates'] = false

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Installs/Removes a defined set of packages'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.3'
+version '0.0.4'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_packages/recipes/default.rb
@@ -17,22 +17,29 @@
 # limitations under the License.
 #
 
+pf = node['platform_family']
+
 # Install common packages
 %w(remove install upgrade).each do |act|
   node['coopr_packages']['common'][act].each do |cb|
     package cb do
       action act.to_sym
+      if node['coopr_packages'].key?(pf) && node['coopr_packages'][pf].key?('options')
+        options node['coopr_packages'][pf]['options']
+      end
     end
   end
 end
 
 # Install platform-specific packages
-pf = node['platform_family']
 %w(remove install upgrade).each do |act|
   if node['coopr_packages'].key?(pf) && node['coopr_packages'][pf].key?(act)
     node['coopr_packages'][pf][act].each do |cb|
       package cb do
         action act.to_sym
+        if node['coopr_packages'][pf].key?('options')
+          options node['coopr_packages'][pf]['options']
+        end
       end
     end
   end
@@ -42,13 +49,13 @@ end
 case pf
 when 'debian'
   execute 'update-apt-packages' do
-    command 'apt-get update && apt-get upgrade -y && apt-get install -y unattended-upgrades'
+    command "apt-get #{node['coopr_packages']['debian']['options']} update && apt-get #{node['coopr_packages']['debian']['options']} upgrade && apt-get #{node['coopr_packages']['debian']['options']} install unattended-upgrades"
     environment 'DEBIAN_FRONTEND' => 'noninteractive'
     not_if { node['coopr_packages']['skip_updates'].to_s == 'true' }
   end
 when 'rhel'
   execute 'update-yum-packages' do
-    command 'yum makecache && yum upgrade -y'
+    command "yum #{node['coopr_packages']['rhel']['options']} makecache && yum #{node['coopr_packages']['rhel']['options']} upgrade"
     not_if { node['coopr_packages']['skip_updates'].to_s == 'true' }
   end
 end

--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2012-2015 Cask Data, Inc.
+# Copyright © 2012-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,3 +26,4 @@ gem 'net-ssh', '~> 2.6'
 
 gem 'google-api-client', '~> 0.8.6'
 gem 'addressable', '< 2.5' # dependency of google-api-client, 2.5 requires Ruby 2.0+
+gem 'nokogiri', '< 1.7' # dependency of fog (fog-xml), 1.7 requires Ruby 2.1+


### PR DESCRIPTION
… and upgrades

- [x] add ``node['coopr_packages'][<platform family>]['options']`` attribute string to be passed to all coopr_package operations if defined
- [x] avoids the dpkg noninteractive prompts by setting ``--force-confnew`` as default, which is appropriate in the Coopr context