### PR TITLE
COOPR-820 Do not fail delete on credential validation failure

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -273,8 +273,13 @@ class FogProviderAWS < Coopr::Plugin::Provider
       fields.each do |k, v|
         instance_variable_set('@' + k, v)
       end
-      # Run EC2 credential validation
-      validate!
+      begin
+        # Run EC2 credential validation
+        validate!
+      rescue
+        log.debug 'Credential validation failed, assuming nothing created, setting providerid to nil'
+        providerid = nil
+      end
       # Delete server
       log.debug 'Invoking server delete'
       begin

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -277,7 +277,7 @@ class FogProviderAWS < Coopr::Plugin::Provider
         # Run EC2 credential validation
         validate!
       rescue
-        log.debug 'Credential validation failed, assuming nothing created, setting providerid to nil'
+        log.warn 'Credential validation failed, assuming nothing created, setting providerid to nil'
         providerid = nil
       end
       # Delete server

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -260,7 +260,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
         # validate credentials
         validate!
       rescue
-        log.debug 'Credential validation failed, assuming nothing created, setting providerid to nil'
+        log.warn 'Credential validation failed, assuming nothing created, setting providerid to nil'
         providerid = nil
       end
       # delete server

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -256,8 +256,13 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       fields.each do |k, v|
         instance_variable_set('@' + k, v)
       end
-      # validate credentials
-      validate!
+      begin
+        # validate credentials
+        validate!
+      rescue
+        log.debug 'Credential validation failed, assuming nothing created, setting providerid to nil'
+        providerid = nil
+      end
       # delete server
       log.debug 'Invoking server delete'
 


### PR DESCRIPTION
This causes Coopr to mark a DELETE as successful if credential validation fails. This validation is done in the plugins, and not against the remote API, so it's not necessarily a fatal issue. This simply allows removal of clusters which failed in CREATE due to bad credentials.

```
2017-01-05 13:57:15 -0500 chriss-mbp.fios-router.home.80282 ERROR: Cannot read named key from resource directory: ssh_keys/coopr. Please ensure you have uploaded a key via the UI or API
2017-01-05 13:57:15 -0500 chriss-mbp.fios-router.home.80282 DEBUG: Credential validation failed, assuming nothing created, setting providerid to nil
2017-01-05 13:57:15 -0500 chriss-mbp.fios-router.home.80282 DEBUG: Invoking server delete
2017-01-05 13:57:15 -0500 chriss-mbp.fios-router.home.80282 DEBUG: Delete finished sucessfully: {"status"=>0}
```