### PR TITLE
COOPR-833 Support automatic restart on GCE

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -304,6 +304,12 @@
             "override": true,
             "tip": "Zone"
           },
+          "auto_restart": {
+            "label": "Automatically restart instances on failure",
+            "type": "checkbox",
+            "override": true,
+            "tip": "Automatically restart instances on failure"
+          },
           "provider_hostname": {
             "label": "Set hostname to provider-specific public DNS hostname (overrides DNS suffix)",
             "type": "checkbox",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -346,6 +346,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
     }
     # optional attrs
     server_def[:network] = @network unless @network.to_s == ''
+    server_def[:auto_restart] = @auto_restart
     server_def
   end
 


### PR DESCRIPTION
Allows configuration of automatic restart on instance failure and default to true.