### PR TITLE
COOPR-834 Prevent NPE in CREATE rescue on failed disk creation

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -59,10 +59,11 @@ class FogProviderGoogle < Coopr::Plugin::Provider
 
       # disks are managed separately, so CREATE must first create and confirm the disk to be used
       # handle boot disk
+      @disks = []
       create_disk(@providerid, @google_root_disk_size_gb, @google_root_disk_type, @zone_name, @image)
       disk = confirm_disk(@providerid)
 
-      @disks = [disk]
+      @disks << disk
 
       # handle additional data disks
       if fields['google_data_disk_size_gb']


### PR DESCRIPTION
Simply ensure that `@disks` is always initialized as an empty array.