### PR TITLE
COOPR-765 Disable ANSI in chef-solo output

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -258,7 +258,7 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
     begin
       Net::SSH.start(ipaddress, sshauth['user'], @credentials) do |ssh|
 
-        ssh_exec!(ssh, "#{sudo} chef-solo -j #{@@remote_cache_dir}/#{@task['taskId']}.json -o '#{run_list}'", 'Running Chef-solo')
+        ssh_exec!(ssh, "#{sudo} chef-solo --no-color -j #{@@remote_cache_dir}/#{@task['taskId']}.json -o '#{run_list}'", 'Running Chef-solo')
       end
     rescue Net::SSH::AuthenticationFailed
       raise $!, "SSH Authentication failure for #{ipaddress}: #{$!}", $!.backtrace


### PR DESCRIPTION
This prevents ANSI codes from appearing in Coopr logs or being stored in the cluster JSON.