### PR TITLE
Support user control of iptables flush behavior

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Firewall manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version          '0.1.0'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/recipes/iptables.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/recipes/iptables.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: coopr_firewall
 # Recipe:: iptables
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ when 'debian'
     owner 'root'
     group 'root'
     mode '0755'
-    content "#!/bin/bash\niptables-restore < #{iptable_rules}\n"
+    content "#!/bin/bash\niptables-restore --noflush < #{iptable_rules}\n"
     action :create
   end
 when 'rhel'
@@ -38,13 +38,13 @@ when 'rhel'
 end
 
 execute 'reload-iptables' do
-  command "iptables-restore < #{iptable_rules}"
+  command "iptables-restore --noflush < #{iptable_rules}"
   user 'root'
   action :nothing
 end
 
 template iptable_rules do
   source 'iptables.erb'
-  notifies :run, 'execute[reload-iptables]'
+  notifies :run, 'execute[reload-iptables]', :immediately
   action :create
 end

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -20,11 +20,22 @@
 <% end %>
 COMMIT
 
+*filter
+<% unless node['coopr_firewall']['no_flush'] %>
+
+###
+## Flush filter tables
+###
+
+-F INPUT
+-F FORWARD
+-F OUTPUT
+
+<% end %>
 ###
 ## Set defaults
 ###
 
-*filter
 # node['coopr_firewall']['INPUT_policy']
 <% if node['coopr_firewall']['INPUT_policy'] %>
 :INPUT <%= node['coopr_firewall']['INPUT_policy'] =%> [0:0]


### PR DESCRIPTION
By default, `iptables-restore` will flush all iptables rules before applying its given ruleset. This will disable this feature and put flush control in the user's hands.