### PR TITLE
Accept traffic from Docker devices

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -69,6 +69,12 @@ COMMIT
 
 # Allow all traffic from loopback
 -A INPUT -i lo -j ACCEPT 
+<% node['network']['interfaces'].each do |n, v| %>
+# Allow all traffic from Docker interfaces
+<% if v.key?('type') && v['type'] == 'docker' %>
+-A INPUT -i <%= n =%> -j ACCEPT
+<% end %>
+<% end %>
 
 ###
 ## Nodes


### PR DESCRIPTION
Use `ohai` detected interface information and automatically ACCEPT traffic from any interface with type `docker` as it's always local.