### PR TITLE
Update Coopr firewall

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,5 @@ Metrics/MethodLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Firewall manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version          '0.1.0'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Firewall manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/recipes/iptables.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/recipes/iptables.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: coopr_firewall
 # Recipe:: iptables
 #
-# Copyright © 2013-2014 Cask Data, Inc.
+# Copyright © 2013-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ when 'debian'
     owner 'root'
     group 'root'
     mode '0755'
-    content "#!/bin/bash\niptables-restore < #{iptable_rules}\n"
+    content "#!/bin/bash\niptables-restore --noflush < #{iptable_rules}\n"
     action :create
   end
 when 'rhel'
@@ -38,13 +38,13 @@ when 'rhel'
 end
 
 execute 'reload-iptables' do
-  command "iptables-restore < #{iptable_rules}"
+  command "iptables-restore --noflush < #{iptable_rules}"
   user 'root'
   action :nothing
 end
 
 template iptable_rules do
   source 'iptables.erb'
-  notifies :run, 'execute[reload-iptables]'
+  notifies :run, 'execute[reload-iptables]', :immediately
   action :create
 end

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -80,6 +80,12 @@ COMMIT
 
 # Allow all traffic from loopback
 -A INPUT -i lo -j ACCEPT 
+<% node['network']['interfaces'].sort.each do |n, v| %>
+# Allow all traffic from Docker interfaces
+<% if v.key?('type') && v['type'] == 'docker' %>
+-A INPUT -i <%= n =%> -j ACCEPT
+<% end %>
+<% end %>
 
 ###
 ## Nodes

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -20,11 +20,22 @@
 <% end %>
 COMMIT
 
+*filter
+<% unless node['coopr_firewall']['no_flush'] %>
+
+###
+## Flush filter tables
+###
+
+-F INPUT
+-F FORWARD
+-F OUTPUT
+
+<% end %>
 ###
 ## Set defaults
 ###
 
-*filter
 # node['coopr_firewall']['INPUT_policy']
 <% if node['coopr_firewall']['INPUT_policy'] %>
 :INPUT <%= node['coopr_firewall']['INPUT_policy'] =%> [0:0]

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -9,7 +9,7 @@
 :OUTPUT ACCEPT [0:0]
 <% if node['coopr_firewall']['notrack_ports'] %>
 # NOTRACK ports
-<% node['coopr_firewall']['notrack_ports'].each do |p| %>
+<% node['coopr_firewall']['notrack_ports'].sort.each do |p| %>
 -A PREROUTING -p tcp --dport <%= p =%> -j NOTRACK
 -A OUTPUT -p tcp --sport <%= p =%> -j NOTRACK
 -A OUTPUT -p tcp --dport <%= p =%> -j NOTRACK
@@ -61,14 +61,14 @@ COMMIT
 
 <% if node['coopr_firewall']['open_tcp_ports'] %>
 # Open TCP ports
-<% node['coopr_firewall']['open_tcp_ports'].each do |p| %>
+<% node['coopr_firewall']['open_tcp_ports'].sort.each do |p| %>
 -A INPUT -p tcp --dport <%= p =%> -j ACCEPT
 <% end %>
 <% end %>
 
 <% if node['coopr_firewall']['open_udp_ports'] %>
 # Open UDP ports
-<% node['coopr_firewall']['open_udp_ports'].each do |p| %>
+<% node['coopr_firewall']['open_udp_ports'].sort.each do |p| %>
 -A INPUT -p udp --dport <%= p =%> -j ACCEPT
 -A INPUT -p udp --sport <%= p =%> -j ACCEPT
 <% end %>
@@ -100,14 +100,14 @@ COMMIT
 
 <% if node['coopr_firewall']['whitelist_nodes'] %>
 # Whitelisted nodes
-<% node['coopr_firewall']['whitelist_nodes'].each do |n| %>
+<% node['coopr_firewall']['whitelist_nodes'].sort.each do |n| %>
 -A INPUT -s <%= n =%> -j ACCEPT
 <% end %>
 
 <% end %>
 <% if node['coopr_firewall']['blacklist_nodes'] %>
 # Blacklisted nodes
-<% node['coopr_firewall']['blacklist_nodes'].each do |n| %>
+<% node['coopr_firewall']['blacklist_nodes'].sort.each do |n| %>
 -A INPUT -s <%= n =%> -j DROP
 <% end %>
 


### PR DESCRIPTION
Update functionality for Coopr firewall.

- Support user control of iptables flush behavior - By default, `iptables-restore` will flush all iptables rules before applying its given ruleset. This will disable this feature and put flush control in the user's hands.
- Accept traffic from Docker devices - Use `ohai` detected interface information and automatically ACCEPT traffic from any interface with type `docker` as it's always local.
- Sort ports and hosts when writing out rules - Sort arrays before writing, so they're easier to read.

Also, disabling `Style/PercentLiteralDelimiters` cop, since different versions of Rubocop have different requirements and we cannot possibly meet both.