### PR TITLE
Support disabling external IP address on GCE

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -304,6 +304,13 @@
             "override": true,
             "tip": "Zone"
           },
+          "external_ip": {
+            "label": "Associate public IP",
+            "type": "checkbox",
+            "override": true,
+            "default": true,
+            "tip": "Associate public IP"
+          },
           "auto_restart": {
             "label": "Automatically restart instances on failure",
             "type": "checkbox",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -343,6 +343,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       disks: @disks,
       machine_type: @flavor,
       zone_name: @zone_name,
+      external_ip: @external_ip,
       tags: ['coopr']
     }
     # optional attrs


### PR DESCRIPTION
Make adding an external IP address to an instance optional.