### PR TITLE
Only set external_ip if false

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -343,11 +343,11 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       disks: @disks,
       machine_type: @flavor,
       zone_name: @zone_name,
-      external_ip: @external_ip,
       tags: ['coopr']
     }
     # optional attrs
     server_def[:network] = @network unless @network.to_s == ''
+    server_def[:external_ip] = false unless @external_ip.to_s == 'true'
     server_def[:auto_restart] = @auto_restart
     server_def
   end


### PR DESCRIPTION
This fixes #203 by only setting `external_ip` on the Server object if it's false.

Here's the relevant code from `fog` Gem:

```ruby
# ExternalIP is default value for server creation
access_config = {'type' => 'ONE_TO_ONE_NAT', 'name' => 'External NAT'}
# leave natIP undefined to use an IP from a shared ephemeral IP address pool
if options.key? 'externalIp'
  access_config['natIP'] = options.delete 'externalIp'
  # If set to 'false', that would mean user does no want to allocate an external IP
  access_config = nil if access_config['natIP'] == false
end
```
This means that `fog` will completely remove the `access_config` if we set `external_ip` to false. However, anything else is sent to the Google API, so any other use must be a valid and available IP address for that instance's zone. Since we only want to support `ephemeral` or `none` as our options, we only set this if the user has chosen not to get an external address. Otherwise, we let the default `fog` code get an ephemeral IP.

GCE reference: https://cloud.google.com/compute/docs/configure-ip-addresses