### PR TITLE
COOPR-836 GCE Network should be an overridable admin field

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -322,6 +322,13 @@
             "type": "checkbox",
             "override": true,
             "tip": "Set hostname to provider-specific public DNS hostname (overrides DNS suffix)"
+          },
+          "network": {
+            "label": "Network name",
+            "type": "text",
+            "override": true,
+            "default": "default",
+            "tip": "Google network for the instances"
           }
         },
         "required": [
@@ -332,18 +339,6 @@
             "ssh_key_resource",
             "zone_name"
           ]
-        ]
-      },
-      "user": {
-        "fields": {
-          "network": {
-            "label": "Network",
-            "type": "text",
-            "tip": "Google custom network"
-          }
-        },
-        "required": [
-          []
         ]
       }
     }


### PR DESCRIPTION
Move Google's `network` from a user field to an admin field, which is overridable. This allows the network default to be set at the provider, so users don't need to modify it at cluster instantiation to use a default network other than "default" on their instances.