### PR TITLE
Reverse logic to check false, not true

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -349,7 +349,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
     }
     # optional attrs
     server_def[:network] = @network unless @network.to_s == ''
-    server_def[:external_ip] = false unless @external_ip.to_s == 'true'
+    server_def[:external_ip] = false if @external_ip.to_s == 'false'
     server_def[:auto_restart] = @auto_restart
     server_def
   end


### PR DESCRIPTION
Reverse the logic to only add this attribute when the field value is `false` and do nothing for all other values. This prevents Coopr from requiring the user to modify their providers to explicitly enable this. Otherwise, using the API directly versus the UI will not populate this field with the default value of `true` and the provisioner will assume that means false (nil.to_s != 'true')