### PR TITLE
Forward docker interface traffic

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Firewall manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.3.0'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -80,10 +80,14 @@ COMMIT
 
 # Allow all traffic from loopback
 -A INPUT -i lo -j ACCEPT 
+# Allow all traffic from Docker interfaces (if any)
 <% node['network']['interfaces'].sort.each do |n, v| %>
-# Allow all traffic from Docker interfaces
 <% if v.key?('type') && v['type'] == 'docker' %>
 -A INPUT -i <%= n =%> -j ACCEPT
+-A FORWARD -o <%= n =%> -j DOCKER
+-A FORWARD -o <%= n =%> -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -i <%= n =%> ! -o <%= n =%> -j ACCEPT
+-A FORWARD -i <%= n =%> -o <%= n =%> -j ACCEPT
 <% end %>
 <% end %>
 


### PR DESCRIPTION
Duplicate the forwarding rules created by Docker daemon.

This assumes the `DOCKER` chain exists, which it should if we have an interface of type `docker` which we're already checking.