### PR TITLE
Ensure google_root_disk_size_gb is an integer

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -60,7 +60,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
       # disks are managed separately, so CREATE must first create and confirm the disk to be used
       # handle boot disk
       @disks = []
-      create_disk(@providerid, @google_root_disk_size_gb, @google_root_disk_type, @zone_name, @image)
+      create_disk(@providerid, @google_root_disk_size_gb.to_i, @google_root_disk_type, @zone_name, @image)
       disk = confirm_disk(@providerid)
 
       @disks << disk


### PR DESCRIPTION
Otherwise, the comparison on `existing_size_gb` in `create_disk` will be comparing a string versus an integer, which will never match.