### PR TITLE
Allow selection of bootstrap interface

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -304,6 +304,17 @@
             "override": true,
             "tip": "Zone"
           },
+          "bootstrap_interface": {
+            "label": "Bootstrap interface",
+            "type": "select",
+            "options": [
+              "access_v4",
+              "bind_v4"
+            ],
+            "default": "access_v4",
+            "override": true,
+            "tip": "Interface Coopr will use for connecting to instance"
+          },
           "external_ip": {
             "label": "Associate public IP",
             "type": "checkbox",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -152,11 +152,18 @@ class FogProviderGoogle < Coopr::Plugin::Provider
         end
 
       bind_ip = server.private_ip_address
-      bootstrap_ip =
+      access_ip =
         if server.public_ip_address
           server.public_ip_address
         else
           bind_ip
+        end
+
+      bootstrap_ip =
+        if @bootstrap_interface == 'bind_v4'
+          bind_ip
+        else
+          access_ip
         end
       if bootstrap_ip.nil?
         log.error 'No IP address available for bootstrapping.'
@@ -170,7 +177,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
 
       # Process results
       @result['ipaddresses'] = {
-        'access_v4' => bootstrap_ip,
+        'access_v4' => access_ip,
         'bind_v4' => bind_ip
       }
       @result['hostname'] = hostname


### PR DESCRIPTION
This allows the user to select the bootstrap interface, which is the interface that Coopr will use for communication between the provisioner and the instance. It's also the interface which will have its IP address returned to Coopr for access.