### PR TITLE
Restrict fog-core version

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Installs/Configures DNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.2.1'
 
 depends 'dnsimple'
 depends 'dynect'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/dnsimple.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/dnsimple.rb
@@ -47,6 +47,12 @@ if subdomain_whitelist.nil? || subdomain_whitelist.include?(subdomain)
   r = package( zpkg ) { action :nothing }
   r.run_action( :install )
 
+  chef_gem 'fog-core' do
+    version '1.43.0' # newer requires xmlrpc which requires ruby >= 2.3
+    compile_time true if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
+    action :install
+  end
+
   include_recipe 'dnsimple'
 
   # Get credentials

--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -22,6 +22,7 @@ source 'https://rubygems.org'
 
 gem 'fog', '~> 1.36.0'
 gem 'fog-profitbricks', '< 2.0' # requires a newer fog 1.42+
+gem 'fog-core', '1.43.0' # newer requires Ruby 2.3+
 gem 'net-ssh', '~> 2.6'
 
 gem 'google-api-client', '~> 0.8.6'


### PR DESCRIPTION
Newer versions of fog-core require xmlrpc, which requires Ruby >= 2.3 and our Chef version doesn't ship that new of a Ruby.