### PR TITLE
add nil checks to allow use outside coopr

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@cask.co'
 license          'Apache 2.0'
 description      'Firewall manager'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.3.1'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_firewall/templates/default/iptables.erb
@@ -96,10 +96,14 @@ COMMIT
 ###
 
 # This cluster (automatic)
+<% if node.key?('coopr') && node['coopr'].key?('cluster') && node['coopr']['cluster'].key?('nodes') %>
 <% node['coopr']['cluster']['nodes'].each do |n, v| %>
+<% next unless v.key?('ipaddresses'] && v['ipaddresses'].key?('access_v4') %>
 -A INPUT -s <%= v['ipaddresses']['access_v4'] =%> -j ACCEPT
+<% next unless v.key?('ipaddresses'] && v['ipaddresses'].key?('bind_v4') %>
 <% next if v['ipaddresses']['bind_v4'] == v['ipaddresses']['access_v4'] %>
 -A INPUT -s <%= v['ipaddresses']['bind_v4'] =%> -j ACCEPT
+<% end %>
 <% end %>
 
 <% if node['coopr_firewall']['whitelist_nodes'] %>


### PR DESCRIPTION
prevents nilpointer exceptions when using this cookbook outside of a Coopr context