### PR TITLE
Fix #210 by using bootstrap_ip as access_v4

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/google.rb
@@ -177,7 +177,7 @@ class FogProviderGoogle < Coopr::Plugin::Provider
 
       # Process results
       @result['ipaddresses'] = {
-        'access_v4' => access_ip,
+        'access_v4' => bootstrap_ip,
         'bind_v4' => bind_ip
       }
       @result['hostname'] = hostname


### PR DESCRIPTION
The code in #210 would return a proper bootstrap_ip based on the user's selection, but `access_v4` was written as access_ip, always, so unless we also did not have a public address, this would send traffic ovet the public address.

This allows an instance to have a public address, but with a fully restricted ingress firewall on GCP, since all access will happen over the `bind_v4` address. This was the intent of #210 but this change was missed.