### PR TITLE
update chef url and catch failures

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/chef_solo_automator.rb
@@ -312,12 +312,12 @@ class ChefSoloAutomator < Coopr::Plugin::Automator
 
         # determine if curl is installed, else default to wget
         chef_version = '12.4.3'
-        chef_install_cmd = "curl -L https://www.chef.io/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
+        chef_install_cmd = "set -o pipefail && curl --fail -L https://omnitruck.chef.io/install.sh | #{sudo} bash -s -- -v #{chef_version}"
         begin
           ssh_exec!(ssh, 'which curl', 'Checking for curl')
         rescue CommandExecutionError
           log.debug 'curl not found, defaulting to wget'
-          chef_install_cmd = "wget -qO - https://www.chef.io/chef/install.sh | #{sudo} bash -s -- -v #{chef_version}"
+          chef_install_cmd = "set -o pipefail && wget -qO - https://omnitruck.chef.io/install.sh | #{sudo} bash -s -- -v #{chef_version}"
         end
         ssh_exec!(ssh, chef_install_cmd, 'Installing Chef')
       end


### PR DESCRIPTION
- [x] catch failures on the curlpipesudobash cmd by setting pipefail, and passing ``--fail`` to curl (to fail on unsuccessful http code).
- [x] update chef url, per https://docs.chef.io/install_omnibus.html
