### PR TITLE
Feature/rest underscore client deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@
 #
 
 language: ruby
+dist: precise
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,8 @@ group :dependencies do
   gem 'mime-types', '< 3.0'
   gem 'net-scp'
   gem 'rest-client', '~> 1.7'
-  gem 'sinatra', "~> 1.4"
-  gem 'thin', "~> 1.6"
-  gem "deep_merge", '~> 1.0', :require => 'deep_merge/rails_compat'
+  gem 'sinatra', '~> 1.4'
+  gem 'thin', '~> 1.6'
   gem 'public_suffix', '< 1.5.0' # ruby 1.9.3
   gem 'nokogiri', '< 1.7.0' # ruby 1.9.3
   gem 'retriable', '< 3.0.0' # ruby 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,11 @@ group :dependencies do
   gem 'logger'
   gem 'mime-types', '< 3.0'
   gem 'net-scp'
+  gem 'public_suffix', '< 1.5.0' # ruby 1.9.3
   gem 'rest-client', '~> 1.7'
+  gem 'retriable', '< 3.0.0' # ruby 1.9.3
   gem 'sinatra', '~> 1.4'
   gem 'thin', '~> 1.6'
-  gem 'public_suffix', '< 1.5.0' # ruby 1.9.3
-  gem 'retriable', '< 3.0.0' # ruby 1.9.3
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,10 @@ group :dependencies do
   gem 'logger'
   gem 'mime-types', '< 3.0'
   gem 'net-scp'
-  gem 'rest_client', '~> 1.7'
-  gem 'sinatra', '~> 1.4'
-  gem 'thin', '~> 1.6'
+  gem 'rest-client', '~> 1.7'
+  gem 'sinatra', "~> 1.4"
+  gem 'thin', "~> 1.6"
+  gem "deep_merge", '~> 1.0', :require => 'deep_merge/rails_compat'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ group :dependencies do
   gem 'sinatra', "~> 1.4"
   gem 'thin', "~> 1.6"
   gem "deep_merge", '~> 1.0', :require => 'deep_merge/rails_compat'
+  gem 'public_suffix', '< 1.5.0' # ruby 1.9.3
+  gem 'nokogiri', '< 1.7.0' # ruby 1.9.3
+  gem 'retriable', '< 3.0.0' # ruby 1.9.3
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ group :dependencies do
   gem 'sinatra', '~> 1.4'
   gem 'thin', '~> 1.6'
   gem 'public_suffix', '< 1.5.0' # ruby 1.9.3
-  gem 'nokogiri', '< 1.7.0' # ruby 1.9.3
   gem 'retriable', '< 3.0.0' # ruby 1.9.3
 end
 

--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -21,7 +21,7 @@ gem 'json', '~> 1.7.7' # activesupport
 
 require 'json'
 require 'optparse'
-require 'rest_client'
+require 'rest-client'
 require 'tmpdir'
 require 'fileutils'
 require 'rubygems/package'

--- a/lib/provisioner/api.rb
+++ b/lib/provisioner/api.rb
@@ -21,7 +21,7 @@ gem 'json', '~> 1.7.7' # activesupport
 require 'thin'
 require 'sinatra/base'
 require 'json'
-require 'rest_client'
+require 'rest-client'
 
 require_relative 'tenantspec'
 require_relative 'provisioner'

--- a/lib/provisioner/provisioner.rb
+++ b/lib/provisioner/provisioner.rb
@@ -22,7 +22,7 @@ gem 'json', '~> 1.7.7' # activesupport
 require 'thin'
 require 'sinatra/base'
 require 'json'
-require 'rest_client'
+require 'rest-client'
 require 'socket'
 require 'resolv'
 

--- a/lib/provisioner/resourcemanager.rb
+++ b/lib/provisioner/resourcemanager.rb
@@ -20,7 +20,7 @@
 require_relative 'logging'
 
 require 'pathname'
-require 'rest_client'
+require 'rest-client'
 require 'tmpdir'
 require 'fileutils'
 require 'rubygems/package'

--- a/lib/provisioner/rest-helper.rb
+++ b/lib/provisioner/rest-helper.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-require 'rest_client'
+require 'rest-client'
 require 'openssl'
 
 module Coopr

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -21,7 +21,7 @@ gem 'json', '~> 1.7.7' # activesupport
 
 require 'json'
 require 'optparse'
-require 'rest_client'
+require 'rest-client'
 require 'socket'
 require 'logger'
 require 'fileutils'

--- a/lib/provisioner/worker/pluginmanager.rb
+++ b/lib/provisioner/worker/pluginmanager.rb
@@ -17,7 +17,7 @@
 #
 
 require 'json'
-require 'rest_client'
+require 'rest-client'
 require_relative '../plugin/automator'
 require_relative '../plugin/provider'
 require_relative 'signalhandler'


### PR DESCRIPTION
fixes [COOPR-695](https://issues.cask.co/browse/COOPR-695).  Since ``rest_client`` has been removed from rubygems now, this is more urgent.

A few more gems needed to be constrained to support ruby 1.9.3 (though we should drop this soon).

I built a standalone to test