### PR TITLE
Support gp2 EBS volume type

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/fog_provider.json
@@ -68,6 +68,17 @@
             "default": true,
             "tip": "Delete EBS volumes on termination"
           },
+          "aws_root_ebs_volume_type": {
+            "label": "Root disk type",
+            "type": "select",
+            "options": [
+              "standard",
+              "gp2"
+            ],
+            "default": "standard",
+            "override": true,
+            "tip": "Disk type"
+          },
           "security_groups": {
             "label": "Security Groups",
             "type": "text",

--- a/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/lib/fog_provider/aws.rb
@@ -396,17 +396,13 @@ class FogProviderAWS < Coopr::Plugin::Provider
             ami_map['volumeSize'].to_s
           end
         end
-      delete_term =
-        if @aws_ebs_delete_on_term
-          'true'
-        else
-          'false'
-        end
+      delete_term = @aws_ebs_delete_on_term.to_s
       server_def[:block_device_mapping] =
         [{
           'DeviceName' => ami_map['deviceName'],
+          'Ebs.DeleteOnTermination' => delete_term,
           'Ebs.VolumeSize' => ebs_size,
-          'Ebs.DeleteOnTermination' => delete_term
+          'Ebs.VolumeType' => @aws_root_ebs_volume_type
         }]
     end
 


### PR DESCRIPTION
Support selection of gp2 volume type for root EBS volumes. These
are general purpose SSD and provide much better performance and
can have volumes up to 16TB.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>