### PR TITLE
Restrict jwt Ruby Gem

### DIFF
--- a/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
+++ b/lib/provisioner/worker/plugins/providers/fog_provider/Gemfile
@@ -26,5 +26,6 @@ gem 'fog-core', '1.43.0' # newer requires Ruby 2.3+
 gem 'net-ssh', '~> 2.6'
 
 gem 'google-api-client', '~> 0.8.6'
+gem 'jwt', '~> 1.5.6' # deep dependency of google-api-client, 2.0 requires Ruby 2.1+
 gem 'addressable', '< 2.5' # dependency of google-api-client, 2.5 requires Ruby 2.0+
 gem 'nokogiri', '< 1.7' # dependency of fog (fog-xml), 1.7 requires Ruby 2.1+


### PR DESCRIPTION
The google-api-client has a deep dependency on jwt, and starting
with jwt 2.0.0, it requires Ruby 2.1+, so restrict it.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>