### PR TITLE
Move rake to test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2012-2015 Cask Data, Inc.
+# Copyright © 2012-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
 #
 
 source 'https://rubygems.org'
-
-gem 'rake'
 
 group :dependencies do
   # These gems are used by the provisioner
@@ -34,6 +32,7 @@ end
 
 group :test do
   gem 'rack-test', '~> 0.6'
+  gem 'rake'
   gem 'rspec', '~> 3.0'
   # rubocop: disable Lint/UnneededDisable
   # rubocop: disable Bundler/DuplicatedGem


### PR DESCRIPTION
There are no uses of rake except for testing, so move it to the
test group.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>