### PR TITLE
specify default class explicitly in rescue clauses per rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,8 +55,6 @@ Style/VariableName:
     - 'lib/provisioner/worker/pluginmanager.rb'
 
 # Manually-added
-Lint/RescueWithoutErrorClass:
-  Enabled: false
 Performance/HashEachMethods:
   Enabled: false
 Style/Dir:

--- a/bin/data-uploader.rb
+++ b/bin/data-uploader.rb
@@ -331,7 +331,7 @@ rescue ArgumentError => e
   puts "Argument Error: #{e.message}"
   puts 'run with  -h or --help to get usage help'
   exit 1
-rescue => e
+rescue StandardError => e
   puts "Error: #{e.message} #{e.backtrace}"
   puts e.backtrace
   exit 1

--- a/lib/provisioner/api.rb
+++ b/lib/provisioner/api.rb
@@ -43,7 +43,7 @@ module Coopr
       get '/heartbeat' do
         begin
           settings.provisioner.heartbeat.to_json
-        rescue
+        rescue StandardError
           halt 500
         end
       end
@@ -63,7 +63,7 @@ module Coopr
 
           data['status'] = 0
           body data.to_json
-        rescue
+        rescue StandardError
           halt 500
         end
       end
@@ -85,7 +85,7 @@ module Coopr
 
           data['status'] = 0
           body data.to_json
-        rescue
+        rescue StandardError
           halt 500
         end
       end
@@ -98,7 +98,7 @@ module Coopr
           else
             halt 404
           end
-        rescue
+        rescue StandardError
           halt 500
         end
       end

--- a/lib/provisioner/config.rb
+++ b/lib/provisioner/config.rb
@@ -77,7 +77,7 @@ module Coopr
             @properties[p_name.downcase] = p_value
             @descriptions[p_name.downcase] = p_description
           end
-        rescue => e
+        rescue StandardError => e
           puts "Exception during parsing of config file: #{file}: #{e.message}, #{e.backtrace}"
           exit(1)
         end

--- a/lib/provisioner/plugin/automator.rb
+++ b/lib/provisioner/plugin/automator.rb
@@ -39,7 +39,7 @@ module Coopr
         ipaddress = @task['config']['ipaddresses']['access_v4']
         fields = begin
                    @task['config']['service']['action']['fields']
-                 rescue
+                 rescue StandardError
                    nil
                  end
 

--- a/lib/provisioner/provisioner.rb
+++ b/lib/provisioner/provisioner.rb
@@ -203,7 +203,7 @@ module Coopr
                 log.warn "Response code #{resp.code}, #{resp.to_str} when sending heartbeat to coopr server #{uri}"
               end
             end
-          rescue => e
+          rescue StandardError => e
             log.error "Caught exception sending heartbeat to coopr server #{uri}: #{e.message}"
           end
           sleep 10
@@ -249,7 +249,7 @@ module Coopr
         else
           log.warn "Response code #{resp.code}, #{resp.to_str} when registering with coopr server #{uri}"
         end
-      rescue => e
+      rescue StandardError => e
         log.error "Caught exception when registering with server #{uri}: #{e.message}"
       end
     end
@@ -274,7 +274,7 @@ module Coopr
         else
           log.warn "Response code #{resp.code}, #{resp.to_str} when unregistering with coopr server #{uri}"
         end
-      rescue => e
+      rescue StandardError => e
         log.error "Caught exception when unregistering with coopr server #{uri}: #{e.message}"
       end
     end
@@ -354,7 +354,7 @@ module Coopr
     def local_ip
       server_ip = begin
                     Resolv.getaddress(@server_uri.sub(%r{^https?://}, '').split(':').first)
-                  rescue
+                  rescue StandardError
                     '127.0.0.1'
                   end
       orig = Socket.do_not_reverse_lookup
@@ -363,7 +363,7 @@ module Coopr
         s.connect server_ip, 1
         s.addr.last
       end
-    rescue => e
+    rescue StandardError => e
       log.error 'Unable to determine provisioner.register.ip, defaulting to 127.0.0.1. Please set it explicitly. '\
         "Server may not be able to connect to this provisioner: #{e.inspect}"
       '127.0.0.1'

--- a/lib/provisioner/resourcemanager.rb
+++ b/lib/provisioner/resourcemanager.rb
@@ -150,7 +150,7 @@ module Coopr
       log.debug "fetching resource at #{uri} for tenant #{@tenant}"
       begin
         response = Coopr::RestHelper.get(uri, 'Coopr-UserID' => 'admin', 'Coopr-TenantID' => @tenant)
-      rescue => e
+      rescue StandardError => e
         log.error "unable to fetch resource: #{e.inspect}"
         return
       end

--- a/lib/provisioner/worker.rb
+++ b/lib/provisioner/worker.rb
@@ -178,12 +178,12 @@ module Coopr
       # automator take pecedence as presence indicates a 'software' task
       providerName = begin
                        task['config']['provider']['providertype']
-                     rescue
+                     rescue StandardError
                        nil
                      end
       automatorName = begin
                         task['config']['service']['action']['type']
-                      rescue
+                      rescue StandardError
                         nil
                       end
 
@@ -231,7 +231,7 @@ module Coopr
       sigterm.dont_interupt do
         result = delegate_task(task)
       end
-    rescue => e
+    rescue StandardError => e
       log.error "Caught exception when running task from file #{@file}"
 
       result = {} if result.nil? == true
@@ -257,7 +257,7 @@ module Coopr
         begin
           response = Coopr::RestHelper.post "#{server_uri}/v2/tasks/take", postdata
           break response
-        rescue => e
+        rescue StandardError => e
           log.error "Unable to connect to Coopr Server #{server_uri}/v2/tasks/take: #{e}"
           sleep poll_error_interval
         end
@@ -281,7 +281,7 @@ module Coopr
           else
             log.error "Received error code #{response.code} from coopr server: #{response.to_str}"
           end
-        rescue => e
+        rescue StandardError => e
           log.error "Caught exception processing response from coopr server: #{e.inspect}"
         end
         sleep poll_error_interval
@@ -319,10 +319,10 @@ module Coopr
             log.debug "Task <#{task['taskId']}> completed, updating results <#{result}>"
             begin
               response = Coopr::RestHelper.post "#{server_uri}/v2/tasks/finish", result.to_json
-            rescue => e
+            rescue StandardError => e
               log.error "Caught exception posting back to coopr server #{server_uri}/v2/tasks/finish: #{e}"
             end
-          rescue => e
+          rescue StandardError => e
             result = {} if result.nil? == true
             result['status'] = '1'
             result['workerId'] = @worker_id
@@ -340,7 +340,7 @@ module Coopr
             log.error "Task <#{task['taskId']}> failed, updating results <#{result}>"
             begin
               response = Coopr::RestHelper.post "#{server_uri}/v2/tasks/finish", result.to_json
-            rescue => e
+            rescue StandardError => e
               log.error "Caught exception posting back to server #{server_uri}/v2/tasks/finish: #{e}"
             end
           end

--- a/lib/provisioner/worker/pluginmanager.rb
+++ b/lib/provisioner/worker/pluginmanager.rb
@@ -107,7 +107,7 @@ module Coopr
             log.error "Could not load plugin, invalid json at #{jsonfile}: #{e.message}"
             @load_errors.push("Could not load plugin, invalid json at #{jsonfile}")
             next
-          rescue => e
+          rescue StandardError => e
             log.error "Could not load plugin at #{jsonfile}: #{e.message}"
             @load_errors.push("Could not load plugin at #{jsonfile}")
             next
@@ -136,13 +136,13 @@ module Coopr
             log.error "Response code #{resp.code}, #{resp.to_str} when trying to register #{name}"
             @register_errors.push("Response code #{resp.code}, #{resp.to_str} when trying to register #{name}")
           end
-        rescue => e
+        rescue StandardError => e
           log.error "Caught exception registering plugins to coopr server #{uri}"
           log.error e.message
           log.error e.backtrace.inspect
           @register_errors.push("Caught exception registering plugins to coopr server #{uri}")
         end
-      rescue => e
+      rescue StandardError => e
         log.error "Caught exception registering plugins to coopr server #{uri}"
         log.error e.message
         log.error e.backtrace.inspect


### PR DESCRIPTION
fixes rubocop `Lint/RescueWithoutErrorClass` / `Style/RescueStandardError`.

`StandardError` is the `rescue` default and so there is no actual change in behavior in this PR