### PR TITLE
yum-mysql-community support

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/README.md
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/README.md
@@ -41,6 +41,28 @@ Additionally, the attribute:
   }
 }
 ```
-will cause it to also create the ``mysql-example`` service and start it.
+will cause it to also create the ``mysql-example`` service and run the ``:start`` action.
 
 In a coopr context, this json can be stored in either a service or a clustertemplate.  The ``action`` attribute can be used for stop and start actions.
+
+
+## Platform-specific repository setup
+
+In the 8.x mysql cookbook series, it is the user's responsibility to configure the appropriate repositories if necessary.  Currently, the
+``yum-mysql-community`` cookbook is implemented for the rhel, fedora, and amazon platform families.  On these platforms, the example JSON
+above would be translated to the following resource call:
+
+```
+mysql_service 'example' do
+  bind_address '0.0.0.0'
+  port '3307'
+  initial_root_passord 'change me'
+  version node['coopr_mysql']['yum_mysql_community']['default_version']
+end
+```
+
+Additionally, the appropriate recipe from the ``yum-mysql-community`` cookbook would be run.
+
+A ``{ "coopr_mysql": { "mysql_service": { "example": { "version": "X.Y" }}}}`` attributed could also be specified in the JSON
+and it will take precedence over the ``default_version`` cookbook attribute.  Note that this would be a platform-specific attribute
+and would therefore require restricting the Coopr clustertemplate to the appropriate platform(s).

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/attributes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/attributes/default.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: coopr_mysql
+# Attribute:: default
+#
+# Copyright © 2018 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# When running on rhel family, optionally configure mysql community repos.
+default['coopr_mysql']['yum_mysql_community']['enabled'] = true
+
+# This default version is applied when {'coopr_mysql': {'mysql_service': {'<name>': {'version': 'x.y'}}}}
+# is not set. This ensures the repos we configure match the version used by the mysql cookbook.
+default['coopr_mysql']['yum_mysql_community']['default_version'] = '5.7'
+

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/metadata.rb
@@ -4,7 +4,8 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Manage MySQL database instances'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.0'
+version '0.2.0'
 
 depends 'mysql', '~> 8.0'
 depends 'yum', '>= 3.0'
+depends 'yum-mysql-community', '~> 2.0'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/recipes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: coopr_mysql
 # Recipe:: default
 #
-# Copyright © 2018 Cask Data, Inc.
+# Copyright © 2017-2018 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ if node.key?('coopr_mysql')
             node['coopr_mysql']['yum_mysql_community']['default_version']
           end
         community_recipe = "mysql#{version.tr('.', '')}"
-        include_recipe "yum-mysql-community::#{community_recipe}"
+        include_recipe "yum-mysql-community::mysql#{version.tr('.', '')}"
       end
 
       # Create the mysql_service resource


### PR DESCRIPTION
Uses ``yum-mysql-community`` to configure the mysql repositories when running on ``rhel`` and similar platforms.  This is required for centOS7+, and encouraged for previous versions.  This does change the default behavior on centOS6 from using the epel 5.1, to the community default 5.7.  This behavior can still be disabled, but I think enabling it by default is the right thing to do.

requires dependency cookbook import https://github.com/caskdata/coopr-provisioner/pull/239