### PR TITLE
default mysql to 5.5

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/attributes/default.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/attributes/default.rb
@@ -22,5 +22,5 @@ default['coopr_mysql']['yum_mysql_community']['enabled'] = true
 
 # This default version is applied when {'coopr_mysql': {'mysql_service': {'<name>': {'version': 'x.y'}}}}
 # is not set. This ensures the repos we configure match the version used by the mysql cookbook.
-default['coopr_mysql']['yum_mysql_community']['default_version'] = '5.7'
+default['coopr_mysql']['yum_mysql_community']['default_version'] = '5.5'
 

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_mysql/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Manage MySQL database instances'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.0'
+version '0.3.0'
 
 depends 'mysql', '~> 8.0'
 depends 'yum', '>= 3.0'


### PR DESCRIPTION
changing the default mysql version to 5.5, since 5.6 and up have some incompatibilities with the default versions of `mysql-connector-java` in the centOS[6,7] repos.  See Note [here](https://www.cloudera.com/documentation/enterprise/5-8-x/topics/cdh_ig_hive_metastore_configure.html#topic_18_4_3)