### PR TITLE
add retry for gdns atomic api

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Installs/Configures DNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.0'
+version          '1.1.1'
 
 depends 'dnsimple', '>= 2.0'
 depends 'dynect'

--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/google.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/recipes/google.rb
@@ -92,6 +92,8 @@ if subdomain_whitelist.nil? || subdomain_whitelist.include?(subdomain)
   end
 
   # Create record set
+  # Retry with random delay. GDNS API is atomic, and there is a possibility of collisions with other provisioners
+  # https://cloud.google.com/dns/docs/troubleshooting#preconditionfailed
   gdns_resource_record_set "#{fqdn}." do
     action :create
     managed_zone gdns['managed_zone']
@@ -103,5 +105,7 @@ if subdomain_whitelist.nil? || subdomain_whitelist.include?(subdomain)
     project gdns['project']
     credential 'coopr-dns-service-account-creds'
     not_if { subdomain == 'local' || subdomain == 'provider' }
+    retries 5
+    retry_delay 5 + rand(15)
   end
 end


### PR DESCRIPTION
- [x] adds a retries with random delays to GDNS atomic record updates, to workaround concurrency issues when multiple provisioners are attempting to update DNS at the same time, resulting in  [this error](https://cloud.google.com/dns/docs/troubleshooting#preconditionfailed).