### PR TITLE
constrain dependency gem

### DIFF
--- a/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
+++ b/lib/provisioner/worker/plugins/automators/chef_solo_automator/resources/cookbooks/coopr_dns/metadata.rb
@@ -4,8 +4,12 @@ maintainer_email 'ops@cask.co'
 license          'All rights reserved'
 description      'Installs/Configures DNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.1'
+version          '1.1.2'
 
 depends 'dnsimple', '>= 2.0'
 depends 'dynect'
 depends 'google-gdns'
+
+# constrain transitive dependency brought in by google-gauth
+# as 0.12.0 is incompatible with the ruby versions in chef 12
+gem 'signet', '0.11.0'


### PR DESCRIPTION
otherwise all provisions fail with current ancient chef version:
```
Installing signet 0.12.0

Gem::InstallError: signet requires Ruby version >= 2.4.0.
```